### PR TITLE
Scaffold Go module, cobra CLI skeleton, and CI (#1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Built binary
+/adl
+
+# Test/coverage artifacts
+*.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md — agentform
+
+Agentform is "Terraform for AI agents": a declarative HCL spec compiled to agent frameworks or reconciled against hosted platforms. **SPEC.md is the source of truth** — read it before making design decisions. If code and SPEC.md conflict, flag it; don't silently diverge.
+
+## What this is
+
+- Go CLI (`adl`) that parses `.agent`, `.tool`, `.prompt`, and `adl.hcl` project files
+- Two execution paths: `adl build` (codegen → LangGraph first) and `adl plan/apply` (platform reconciler → OpenAI Assistants first)
+- Non-goals for v0: being a runtime, executing agents, eval harnesses
+
+## Architecture
+
+```
+cmd/adl/            CLI entrypoint (cobra)
+internal/
+  parser/           HCL decode (hashicorp/hcl/v2) → AST
+  schema/           typed config structs, validation, reference resolution
+  graph/            DAG construction, cycle detection, topo sort
+  build/            codegen engine + per-target generators (build/langgraph/)
+  provider/         platform reconcilers (provider/openai/)
+  state/            state file read/write, locking, diff
+```
+
+## Commands
+
+```bash
+go build ./...                 # build everything
+go test ./...                  # run all tests
+go test ./internal/parser/     # test one package
+go vet ./...                   # static checks
+gofmt -l .                     # formatting check (must be clean)
+```
+
+## Conventions
+
+- Go 1.22+, standard library first; approved deps: cobra, hashicorp/hcl/v2, go-cmp (tests)
+- All packages under `internal/` except `cmd/`; no public API surface in v0
+- Errors: wrap with `fmt.Errorf("context: %w", err)`; user-facing CLI errors must reference the file/block address that caused them (e.g. `agent.weather: unknown reference model.fastt`)
+- Table-driven tests; fixtures live in `testdata/` per package (valid + invalid HCL samples)
+- Every parser/validation feature needs at least one negative test (bad input → expected diagnostic)
+- Providers implement the common interface: `Read / Create / Update / Delete / Diff`
+- Keep codegen output deterministic — same spec must always produce byte-identical output (needed for testing and CI diffs)
+
+## Domain rules to enforce (from SPEC.md)
+
+- Agent owns model + IO contract; prompts are pure templates with `requires` variables
+- Every prompt variable must be satisfiable from the agent's inputs/outputs → else compile error
+- References (`agent.x.output.y`, `model.x`, `tool.x`, `prompt.x`) build the DAG; cycles are a compile error
+- `depends_on` is the explicit fallback only — never infer data flow from it
+- A tool has exactly one `source` block, `kind` ∈ mcp | http | builtin | runtime | script
+
+## Workflow
+
+- Small PRs mapped to GitHub issues; reference issue number in commits
+- `adl validate` must stay fast — it runs on every save in editor integrations later
+- When adding a block field: update schema struct → validation → parser test fixtures → SPEC.md if it's a design change

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # agentform
+
+Agentform is "Terraform for AI agents." It provides a vendor-neutral, versionable spec (.agent, .tool, .prompt files in HCL) and a Go toolchain with two paths: agentform build generates runnable projects for frameworks like LangGraph, and agentform plan/apply reconciles agents as long-lived resources on hosted platforms like OpenAI Assistants – with state, diffs, and drift detection.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,0 +1,236 @@
+# Agent Definition Language (ADL) — v0 Design Spec
+ 
+> Declarative language for defining, compiling, and managing AI agents.
+> "Terraform for agents": one spec → codegen for frameworks *or* lifecycle management on hosted platforms.
+ 
+Status: **draft v0** · Syntax: **HCL** · Implementation: **Go**
+ 
+---
+ 
+## 1. Vision
+ 
+Agents today are defined imperatively inside frameworks (LangGraph, CrewAI) or clicked together in platform UIs (OpenAI Assistants, Bedrock Agents). There is no vendor-neutral, versionable, reviewable source of truth.
+ 
+ADL provides:
+ 
+1. **A spec** — typed, declarative definitions of agents, tools, prompts, and models.
+2. **A compiler** — generate runnable projects for target frameworks (`adl build`).
+3. **A reconciler** — create/update/destroy agents on hosted platforms with plan/apply/state semantics (`adl plan`, `adl apply`).
+Non-goals (v0): being a runtime, executing agents, evaluation/testing harnesses.
+ 
+---
+ 
+## 2. File Types
+ 
+| Extension | Purpose | Contains |
+|-----------|---------|----------|
+| `.agent`  | Agent definition | model ref, prompt refs, tool refs, IO schema, deps |
+| `.tool`   | Tool specification | interface (params, returns) + implementation source |
+| `.prompt` | Prompt template | frontmatter (name, required variables) + raw body |
+| `.adl` / `adl.hcl` | Project file | project meta, model blocks, targets, defaults |
+ 
+All files in a directory tree form one **module** (like a Terraform module). Files reference each other by block address, not path.
+ 
+---
+ 
+## 3. Block Reference
+ 
+### 3.1 `model` (in project file)
+ 
+```hcl
+model "fast" {
+  provider = "openai"        # openai | anthropic | google | ollama | ...
+  name     = "gpt-4o-mini"
+  params {
+    temperature = 0.2
+    max_tokens  = 4096
+  }
+}
+```
+ 
+Vendor-neutral: agents reference `model.fast`, never raw model strings. Swapping providers is a one-line change.
+ 
+### 3.2 `agent` (.agent file)
+ 
+```hcl
+agent "weather" {
+  description = "Answers weather questions for a location and date"
+ 
+  model         = model.fast
+  system_prompt = prompt.weather_system
+ 
+  tools = [tool.web_search]
+ 
+  input "location" {
+    type        = string
+    description = "The location to get the weather for"
+  }
+ 
+  input "date" {
+    type     = string
+    optional = true
+  }
+ 
+  output "weather" {
+    type = string
+  }
+ 
+  # Implicit dependency: created because we reference agent.forecast
+  input "forecast_context" {
+    type    = string
+    default = agent.forecast.output.summary
+  }
+ 
+  # Explicit fallback when no reference exists (rare)
+  depends_on = [agent.geocoder]
+}
+```
+ 
+**Ownership rules:**
+- Agent owns the **model** and the **IO contract**.
+- Prompt owns only its **template body** and the **variables it requires**.
+- Validation: every variable a prompt requires must be satisfiable from the agent's inputs/outputs; conflict = compile error.
+### 3.3 `tool` (.tool file)
+ 
+A tool is an **interface + implementation source**.
+ 
+```hcl
+tool "web_search" {
+  description = "Search the web"
+ 
+  param "query" {
+    type        = string
+    description = "The query to search for"
+  }
+ 
+  param "max_results" {
+    type    = number
+    default = 10
+  }
+ 
+  param "include_images" {
+    type    = bool
+    default = false
+  }
+ 
+  returns {
+    type = string
+  }
+ 
+  # Exactly one implementation block:
+  source {
+    kind = "mcp"                       # mcp | http | builtin | runtime | script
+    uri  = "mcp://search-server/web_search"
+  }
+}
+```
+ 
+**Source kinds:**
+ 
+| kind | Meaning |
+|------|---------|
+| `mcp` | Tool served by an MCP server |
+| `http` | REST endpoint (OpenAPI-style descriptor) |
+| `builtin` | Provided by target platform (e.g. OpenAI's built-in web search) |
+| `runtime` | Implemented in user code within the generated project (codegen emits a stub) |
+| `script` | Inline/local script executed by generated glue code |
+ 
+### 3.4 `prompt` (.prompt file)
+ 
+Frontmatter + body. Body is the raw prompt; variables use `{{var}}`.
+ 
+```
+---
+name = "weather_system"
+requires = ["location"]
+---
+You are a weather assistant. The user is asking about {{location}}.
+Answer concisely using the provided tools.
+```
+ 
+No model, no IO — prompts are pure templates (per decision #2).
+ 
+### 3.5 `target` (project file)
+ 
+Where the spec goes. Two categories mirror the two verbs:
+ 
+```hcl
+# Codegen target → `adl build`
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+}
+ 
+# Managed platform target → `adl plan` / `adl apply`
+target "openai_assistants" {
+  type = "platform"
+  auth {
+    api_key_env = "OPENAI_API_KEY"
+  }
+}
+```
+ 
+---
+ 
+## 4. Dependency & Reference Semantics
+ 
+- **References create the DAG.** `agent.forecast.output.summary` makes `weather` depend on `forecast`. Same rule for `model.*`, `tool.*`, `prompt.*`.
+- `depends_on` is the explicit escape hatch for ordering without data flow (Terraform-style).
+- Cycles are a compile error.
+- Cross-module references (v1): `module.<name>.agent.<name>` — registry/import system deferred.
+---
+ 
+## 5. CLI
+ 
+| Command | Function |
+|---------|----------|
+| `adl init` | Scaffold project |
+| `adl validate` | Parse + type-check + resolve references |
+| `adl build [-target X]` | Codegen for framework targets |
+| `adl plan` | Diff spec vs. state file vs. remote platform |
+| `adl apply` | Reconcile platform targets, update state |
+| `adl destroy` | Remove managed remote agents |
+| `adl fmt` | Canonical formatting |
+ 
+State file (`adl.state.json`): maps block addresses → remote resource IDs, tracks last-applied config for drift detection.
+ 
+---
+ 
+## 6. Architecture (Go)
+ 
+```
+cmd/adl/            CLI (cobra)
+internal/
+  parser/           HCL decode (hashicorp/hcl/v2) → AST
+  schema/           typed config structs, validation, reference resolution
+  graph/            DAG construction, cycle detection, topo sort
+  build/            codegen engine
+    langgraph/      target: LangGraph (Python)
+    crewai/         target: CrewAI (Python)
+  provider/         platform reconcilers
+    openai/         OpenAI Assistants API
+    bedrock/        AWS Bedrock Agents
+  state/            state file read/write, locking, diff
+```
+ 
+Providers implement a common interface (`Read/Create/Update/Delete/Diff`) — later extractable to a plugin system (go-plugin, like Terraform).
+ 
+---
+ 
+## 7. Deferred to v1+
+ 
+- **Memory/state config** on agents (conversation memory, vector stores)
+- **Guardrails** blocks (input/output filters, budgets, rate limits)
+- Multi-agent orchestration graphs (routing, handoffs) beyond simple references
+- Module registry / package management for sharing `.agent`/`.tool` files
+- Secrets management beyond env vars
+- Remote state backends
+---
+ 
+## 8. v0 Milestones
+ 
+1. Parser + `adl validate` for `.agent`, `.tool`, `.prompt`, project file
+2. `adl build` with **one** codegen target (pick LangGraph)
+3. `adl plan/apply` with **one** platform provider (pick OpenAI Assistants)
+4. Examples repo: the weather agent end-to-end on both paths
+One codegen target + one provider proves the hybrid thesis. Everything else is expansion.

--- a/cmd/adl/main.go
+++ b/cmd/adl/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "adl: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/adl/root.go
+++ b/cmd/adl/root.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "adl",
+		Short:         "Agent Definition Language — declarative AI agent specs",
+		Long:          "adl compiles declarative agent specs (.agent, .tool, .prompt) to agent frameworks or reconciles them against hosted platforms.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	root.AddCommand(newVersionCmd())
+	return root
+}
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the adl version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "adl version %s\n", version)
+			return err
+		},
+	}
+}

--- a/cmd/adl/root_test.go
+++ b/cmd/adl/root_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRootCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		wantOut string
+	}{
+		{
+			name:    "version subcommand prints version",
+			args:    []string{"version"},
+			wantOut: "adl version dev",
+		},
+		{
+			name:    "no args prints help",
+			args:    []string{},
+			wantOut: "Usage:",
+		},
+		{
+			name:    "unknown subcommand errors",
+			args:    []string{"frobnicate"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantOut != "" && !strings.Contains(out.String(), tt.wantOut) {
+				t.Errorf("output = %q, want it to contain %q", out.String(), tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestRootCommandUse(t *testing.T) {
+	if got := newRootCmd().Use; got != "adl" {
+		t.Errorf("root command Use = %q, want %q", got, "adl")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/weirdGuy/agentform
+
+go 1.26.4
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
- go.mod: github.com/weirdGuy/agentform, cobra as the only direct dep
- cmd/adl: root command + version subcommand (ldflags-overridable version)
- GitHub Actions CI: build, test, vet, gofmt check on push/PR