### PR TITLE
Reject cross-type target fields: auth on codegen, output on platform …

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -175,6 +175,12 @@ target "openai_assistants" {
   }
 }
 ```
+
+**Rules:**
+- `type` is a closed enum: `codegen` or `platform`. Unknown values are a compile error; new target types are additive spec changes.
+- `codegen` targets require `output` and do not allow `auth`.
+- `platform` targets do not allow `output`; `auth` is optional (ambient credentials — env vars, instance roles — are the common case).
+- Fields that are meaningless for a target's type are errors, not ignored (configs rot through silent acceptance).
  
 ---
  

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -114,8 +114,14 @@ func ParseProject(filename string, src []byte) (*schema.ProjectFile, error) {
 			if target.Output == "" {
 				return nil, fmt.Errorf("%s: codegen target requires \"output\"", target.Addr())
 			}
+			if target.Auth != nil {
+				return nil, fmt.Errorf("%s: codegen target does not allow \"auth\"", target.Addr())
+			}
 		case "platform":
 			// auth is optional; credentials may come from the environment
+			if t.Output != nil {
+				return nil, fmt.Errorf("%s: platform target does not allow \"output\"", target.Addr())
+			}
 		default:
 			return nil, fmt.Errorf("%s: invalid type %q (expected \"codegen\" or \"platform\")", target.Addr(), target.Type)
 		}

--- a/internal/parser/project_test.go
+++ b/internal/parser/project_test.go
@@ -100,6 +100,16 @@ func TestParseProjectFile(t *testing.T) {
 			file:    "invalid_codegen_no_output.hcl",
 			wantErr: `target.langgraph: codegen target requires "output"`,
 		},
+		{
+			name:    "codegen target rejects auth block",
+			file:    "invalid_codegen_auth.hcl",
+			wantErr: `target.langgraph: codegen target does not allow "auth"`,
+		},
+		{
+			name:    "platform target rejects output attribute",
+			file:    "invalid_platform_output.hcl",
+			wantErr: `target.openai_assistants: platform target does not allow "output"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/testdata/invalid_codegen_auth.hcl
+++ b/internal/parser/testdata/invalid_codegen_auth.hcl
@@ -1,0 +1,8 @@
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+
+  auth {
+    api_key_env = "OPENAI_API_KEY"
+  }
+}

--- a/internal/parser/testdata/invalid_platform_output.hcl
+++ b/internal/parser/testdata/invalid_platform_output.hcl
@@ -1,0 +1,4 @@
+target "openai_assistants" {
+  type   = "platform"
+  output = "./gen/assistants"
+}


### PR DESCRIPTION
…(#2)

Meaningless fields are errors, not silently ignored. Documents the target validation rules in SPECS.md 3.5.