### PR TITLE
Parse .tool files: params, returns, single source with kind enum (#4)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -140,6 +140,15 @@ tool "web_search" {
 | `builtin` | Provided by target platform (e.g. OpenAI's built-in web search) |
 | `runtime` | Implemented in user code within the generated project (codegen emits a stub) |
 | `script` | Inline/local script executed by generated glue code |
+
+**Rules:**
+- `kind` is a closed enum (like `target.type`): `mcp | http | builtin | runtime | script`. Unknown kinds are compile errors.
+- Exactly one `source` block and exactly one `returns` block per tool. Zero `param` blocks is fine.
+- `uri` is required for `mcp`, `http`, and `script` sources; it is an error on `builtin` and `runtime` (they have no external location — the platform or generated stub is the implementation). Meaningless fields are errors, not ignored.
+- Param and returns types are bare keywords, not strings: `type = string`, never `type = "string"`. Closed enum in v0: `string | number | bool` (compound types deferred to v1).
+- `default` must be a literal whose type matches the declared `type`; a mismatch or an explicit `default = null` is a compile error. A param with a `default` is optional at call time; there is no separate `optional` attribute on tool params.
+- `description` is optional on both the tool and its params at parse time (targets may enforce more).
+- A `.tool` file may contain multiple `tool` blocks; duplicate names within a file are a parse error (module-wide duplicates are owned by module loading, issue #6).
  
 ### 3.4 `prompt` (.prompt file)
  

--- a/internal/parser/testdata/invalid_builtin_uri.tool
+++ b/internal/parser/testdata/invalid_builtin_uri.tool
@@ -1,0 +1,10 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+    uri  = "https://example.com/search"
+  }
+}

--- a/internal/parser/testdata/invalid_default_null.tool
+++ b/internal/parser/testdata/invalid_default_null.tool
@@ -1,0 +1,14 @@
+tool "web_search" {
+  param "query" {
+    type    = string
+    default = null
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_default_type.tool
+++ b/internal/parser/testdata/invalid_default_type.tool
@@ -1,0 +1,14 @@
+tool "web_search" {
+  param "max_results" {
+    type    = number
+    default = "ten"
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_dup_param.tool
+++ b/internal/parser/testdata/invalid_dup_param.tool
@@ -1,0 +1,17 @@
+tool "web_search" {
+  param "query" {
+    type = string
+  }
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_dup_tool.tool
+++ b/internal/parser/testdata/invalid_dup_tool.tool
@@ -1,0 +1,19 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}
+
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "runtime"
+  }
+}

--- a/internal/parser/testdata/invalid_mcp_no_uri.tool
+++ b/internal/parser/testdata/invalid_mcp_no_uri.tool
@@ -1,0 +1,9 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "mcp"
+  }
+}

--- a/internal/parser/testdata/invalid_no_returns.tool
+++ b/internal/parser/testdata/invalid_no_returns.tool
@@ -1,0 +1,5 @@
+tool "web_search" {
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_no_source.tool
+++ b/internal/parser/testdata/invalid_no_source.tool
@@ -1,0 +1,5 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+}

--- a/internal/parser/testdata/invalid_param_type.tool
+++ b/internal/parser/testdata/invalid_param_type.tool
@@ -1,0 +1,13 @@
+tool "web_search" {
+  param "query" {
+    type = integer
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_param_type_quoted.tool
+++ b/internal/parser/testdata/invalid_param_type_quoted.tool
@@ -1,0 +1,13 @@
+tool "web_search" {
+  param "query" {
+    type = "string"
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_returns_type.tool
+++ b/internal/parser/testdata/invalid_returns_type.tool
@@ -1,0 +1,9 @@
+tool "web_search" {
+  returns {
+    type = json
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_source_kind.tool
+++ b/internal/parser/testdata/invalid_source_kind.tool
@@ -1,0 +1,10 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "graphql"
+    uri  = "https://example.com/graphql"
+  }
+}

--- a/internal/parser/testdata/invalid_two_returns.tool
+++ b/internal/parser/testdata/invalid_two_returns.tool
@@ -1,0 +1,13 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  returns {
+    type = number
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/parser/testdata/invalid_two_sources.tool
+++ b/internal/parser/testdata/invalid_two_sources.tool
@@ -1,0 +1,13 @@
+tool "web_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+
+  source {
+    kind = "runtime"
+  }
+}

--- a/internal/parser/testdata/valid_full.tool
+++ b/internal/parser/testdata/valid_full.tool
@@ -1,0 +1,27 @@
+tool "web_search" {
+  description = "Search the web"
+
+  param "query" {
+    type        = string
+    description = "The query to search for"
+  }
+
+  param "max_results" {
+    type    = number
+    default = 10
+  }
+
+  param "include_images" {
+    type    = bool
+    default = false
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "mcp"
+    uri  = "mcp://search-server/web_search"
+  }
+}

--- a/internal/parser/testdata/valid_multi.tool
+++ b/internal/parser/testdata/valid_multi.tool
@@ -1,0 +1,38 @@
+tool "scratchpad" {
+  param "note" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "runtime"
+  }
+}
+
+tool "platform_search" {
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}
+
+tool "summarize" {
+  param "text" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "script"
+    uri  = "./scripts/summarize.py"
+  }
+}

--- a/internal/parser/tool.go
+++ b/internal/parser/tool.go
@@ -1,0 +1,195 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+type toolFileHCL struct {
+	Tools []toolHCL `hcl:"tool,block"`
+}
+
+// toolHCL decodes returns and source as slices so cardinality violations get
+// address-prefixed errors instead of generic gohcl diagnostics.
+type toolHCL struct {
+	Label       string           `hcl:"name,label"`
+	Description *string          `hcl:"description"`
+	Params      []toolParamHCL   `hcl:"param,block"`
+	Returns     []toolReturnsHCL `hcl:"returns,block"`
+	Sources     []toolSourceHCL  `hcl:"source,block"`
+}
+
+// toolParamHCL keeps type as a raw expression (it is a bare keyword, not a
+// string value) and default as a cty.Value so an absent attribute (NilVal)
+// stays distinguishable from an explicit null.
+type toolParamHCL struct {
+	Label       string         `hcl:"name,label"`
+	Type        hcl.Expression `hcl:"type"`
+	Description *string        `hcl:"description"`
+	Default     cty.Value      `hcl:"default,optional"`
+}
+
+type toolReturnsHCL struct {
+	Type hcl.Expression `hcl:"type"`
+}
+
+type toolSourceHCL struct {
+	Kind string  `hcl:"kind"`
+	URI  *string `hcl:"uri"`
+}
+
+// paramTypes maps the closed type enum to the cty type a default must have.
+var paramTypes = map[string]cty.Type{
+	"string": cty.String,
+	"number": cty.Number,
+	"bool":   cty.Bool,
+}
+
+// ParseToolFile reads and decodes a tool file (.tool).
+func ParseToolFile(path string) ([]*schema.Tool, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading tool file: %w", err)
+	}
+	return ParseTools(path, src)
+}
+
+// ParseTools decodes tool file source. filename is used in diagnostics.
+func ParseTools(filename string, src []byte) ([]*schema.Tool, error) {
+	file, diags := hclparse.NewParser().ParseHCL(src, filename)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	var raw toolFileHCL
+	if diags := gohcl.DecodeBody(file.Body, nil, &raw); diags.HasErrors() {
+		return nil, diags
+	}
+
+	var tools []*schema.Tool
+	seen := map[string]bool{}
+	for _, t := range raw.Tools {
+		tool, err := decodeTool(t)
+		if err != nil {
+			return nil, err
+		}
+		if seen[tool.Name] {
+			return nil, fmt.Errorf("%s: declared more than once", tool.Addr())
+		}
+		seen[tool.Name] = true
+		tools = append(tools, tool)
+	}
+	return tools, nil
+}
+
+func decodeTool(t toolHCL) (*schema.Tool, error) {
+	tool := &schema.Tool{Name: t.Label}
+	if t.Description != nil {
+		tool.Description = *t.Description
+	}
+
+	seenParams := map[string]bool{}
+	for _, p := range t.Params {
+		param, err := decodeToolParam(tool.Addr(), p)
+		if err != nil {
+			return nil, err
+		}
+		if seenParams[param.Name] {
+			return nil, fmt.Errorf("%s: param %q declared more than once", tool.Addr(), param.Name)
+		}
+		seenParams[param.Name] = true
+		tool.Params = append(tool.Params, param)
+	}
+
+	if len(t.Returns) != 1 {
+		return nil, fmt.Errorf("%s: exactly one \"returns\" block is required, found %d", tool.Addr(), len(t.Returns))
+	}
+	retType, err := typeKeyword(fmt.Sprintf("%s: returns", tool.Addr()), t.Returns[0].Type)
+	if err != nil {
+		return nil, err
+	}
+	tool.Returns = &schema.ToolReturns{Type: retType}
+
+	if len(t.Sources) != 1 {
+		return nil, fmt.Errorf("%s: exactly one \"source\" block is required, found %d", tool.Addr(), len(t.Sources))
+	}
+	source, err := decodeToolSource(tool.Addr(), t.Sources[0])
+	if err != nil {
+		return nil, err
+	}
+	tool.Source = source
+
+	return tool, nil
+}
+
+func decodeToolParam(toolAddr string, p toolParamHCL) (*schema.ToolParam, error) {
+	addr := fmt.Sprintf("%s: param %q", toolAddr, p.Label)
+
+	param := &schema.ToolParam{Name: p.Label}
+	if p.Description != nil {
+		param.Description = *p.Description
+	}
+
+	typ, err := typeKeyword(addr, p.Type)
+	if err != nil {
+		return nil, err
+	}
+	param.Type = typ
+
+	if p.Default != cty.NilVal {
+		if p.Default.IsNull() {
+			return nil, fmt.Errorf("%s: default cannot be null; omit the attribute instead", addr)
+		}
+		if want := paramTypes[typ]; p.Default.Type() != want {
+			return nil, fmt.Errorf("%s: default must be %s, got %s", addr, typ, p.Default.Type().FriendlyName())
+		}
+		goVal, err := ctyToGo(p.Default)
+		if err != nil {
+			return nil, fmt.Errorf("%s: default: %w", addr, err)
+		}
+		param.Default = goVal
+	}
+
+	return param, nil
+}
+
+func decodeToolSource(toolAddr string, s toolSourceHCL) (*schema.ToolSource, error) {
+	source := &schema.ToolSource{Kind: s.Kind}
+	if s.URI != nil {
+		source.URI = *s.URI
+	}
+
+	switch source.Kind {
+	case "mcp", "http", "script":
+		if s.URI == nil {
+			return nil, fmt.Errorf("%s: source kind %q requires \"uri\"", toolAddr, source.Kind)
+		}
+	case "builtin", "runtime":
+		if s.URI != nil {
+			return nil, fmt.Errorf("%s: source kind %q does not allow \"uri\"", toolAddr, source.Kind)
+		}
+	default:
+		return nil, fmt.Errorf("%s: invalid source kind %q (expected \"mcp\", \"http\", \"builtin\", \"runtime\", or \"script\")", toolAddr, source.Kind)
+	}
+	return source, nil
+}
+
+// typeKeyword resolves a type attribute written as a bare keyword
+// (type = string) against the closed v0 type enum.
+func typeKeyword(addr string, expr hcl.Expression) (string, error) {
+	kw := hcl.ExprAsKeyword(expr)
+	if kw == "" {
+		return "", fmt.Errorf("%s: type must be a bare keyword (string, number, or bool)", addr)
+	}
+	if _, ok := paramTypes[kw]; !ok {
+		return "", fmt.Errorf("%s: invalid type %q (expected string, number, or bool)", addr, kw)
+	}
+	return kw, nil
+}

--- a/internal/parser/tool_test.go
+++ b/internal/parser/tool_test.go
@@ -1,0 +1,162 @@
+package parser_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/parser"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+func TestParseToolFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		want    []*schema.Tool
+		wantErr string // substring the error must contain; empty means no error
+	}{
+		{
+			name: "full tool with typed params, defaults, returns and mcp source",
+			file: "valid_full.tool",
+			want: []*schema.Tool{
+				{
+					Name:        "web_search",
+					Description: "Search the web",
+					Params: []*schema.ToolParam{
+						{Name: "query", Type: "string", Description: "The query to search for"},
+						{Name: "max_results", Type: "number", Default: int64(10)},
+						{Name: "include_images", Type: "bool", Default: false},
+					},
+					Returns: &schema.ToolReturns{Type: "string"},
+					Source:  &schema.ToolSource{Kind: "mcp", URI: "mcp://search-server/web_search"},
+				},
+			},
+		},
+		{
+			name: "multiple tools per file; runtime and builtin sources take no uri, script does",
+			file: "valid_multi.tool",
+			want: []*schema.Tool{
+				{
+					Name:    "scratchpad",
+					Params:  []*schema.ToolParam{{Name: "note", Type: "string"}},
+					Returns: &schema.ToolReturns{Type: "string"},
+					Source:  &schema.ToolSource{Kind: "runtime"},
+				},
+				{
+					Name:    "platform_search",
+					Returns: &schema.ToolReturns{Type: "string"},
+					Source:  &schema.ToolSource{Kind: "builtin"},
+				},
+				{
+					Name:    "summarize",
+					Params:  []*schema.ToolParam{{Name: "text", Type: "string"}},
+					Returns: &schema.ToolReturns{Type: "string"},
+					Source:  &schema.ToolSource{Kind: "script", URI: "./scripts/summarize.py"},
+				},
+			},
+		},
+		{
+			name:    "duplicate tool names are rejected",
+			file:    "invalid_dup_tool.tool",
+			wantErr: `tool.web_search: declared more than once`,
+		},
+		{
+			name:    "duplicate param names are rejected",
+			file:    "invalid_dup_param.tool",
+			wantErr: `tool.web_search: param "query" declared more than once`,
+		},
+		{
+			name:    "param type outside the enum is rejected",
+			file:    "invalid_param_type.tool",
+			wantErr: `tool.web_search: param "query": invalid type "integer" (expected string, number, or bool)`,
+		},
+		{
+			name:    "quoted param type is rejected, types are bare keywords",
+			file:    "invalid_param_type_quoted.tool",
+			wantErr: `tool.web_search: param "query": type must be a bare keyword (string, number, or bool)`,
+		},
+		{
+			name:    "default value must match the declared param type",
+			file:    "invalid_default_type.tool",
+			wantErr: `tool.web_search: param "max_results": default must be number, got string`,
+		},
+		{
+			name:    "null default is rejected",
+			file:    "invalid_default_null.tool",
+			wantErr: `tool.web_search: param "query": default cannot be null; omit the attribute instead`,
+		},
+		{
+			name:    "missing source block is rejected",
+			file:    "invalid_no_source.tool",
+			wantErr: `tool.web_search: exactly one "source" block is required, found 0`,
+		},
+		{
+			name:    "two source blocks are rejected",
+			file:    "invalid_two_sources.tool",
+			wantErr: `tool.web_search: exactly one "source" block is required, found 2`,
+		},
+		{
+			name:    "source kind outside the enum is rejected",
+			file:    "invalid_source_kind.tool",
+			wantErr: `tool.web_search: invalid source kind "graphql" (expected "mcp", "http", "builtin", "runtime", or "script")`,
+		},
+		{
+			name:    "mcp source requires a uri",
+			file:    "invalid_mcp_no_uri.tool",
+			wantErr: `tool.web_search: source kind "mcp" requires "uri"`,
+		},
+		{
+			name:    "builtin source rejects a uri",
+			file:    "invalid_builtin_uri.tool",
+			wantErr: `tool.web_search: source kind "builtin" does not allow "uri"`,
+		},
+		{
+			name:    "missing returns block is rejected",
+			file:    "invalid_no_returns.tool",
+			wantErr: `tool.web_search: exactly one "returns" block is required, found 0`,
+		},
+		{
+			name:    "two returns blocks are rejected",
+			file:    "invalid_two_returns.tool",
+			wantErr: `tool.web_search: exactly one "returns" block is required, found 2`,
+		},
+		{
+			name:    "returns type outside the enum is rejected",
+			file:    "invalid_returns_type.tool",
+			wantErr: `tool.web_search: returns: invalid type "json" (expected string, number, or bool)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.ParseToolFile(filepath.Join("testdata", tt.file))
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ParseToolFile(%s) mismatch (-want +got):\n%s", tt.file, diff)
+			}
+		})
+	}
+}
+
+func TestParseToolFile_MissingFile(t *testing.T) {
+	_, err := parser.ParseToolFile(filepath.Join("testdata", "does_not_exist.tool"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/schema/tool.go
+++ b/internal/schema/tool.go
@@ -1,0 +1,33 @@
+package schema
+
+// Tool is an interface + implementation source decoded from a .tool file
+// (SPEC.md §3.3).
+type Tool struct {
+	Name        string       // block label, e.g. "web_search" in tool.web_search
+	Description string       // optional; surfaced to platforms as the function description
+	Params      []*ToolParam // declaration order
+	Returns     *ToolReturns
+	Source      *ToolSource
+}
+
+// Addr returns the block address used in references and diagnostics.
+func (t *Tool) Addr() string { return "tool." + t.Name }
+
+// ToolParam is one input parameter of a tool.
+type ToolParam struct {
+	Name        string // block label
+	Type        string // "string", "number", or "bool"
+	Description string // optional
+	Default     any    // typed to match Type; nil when the param has no default
+}
+
+// ToolReturns describes a tool's return value.
+type ToolReturns struct {
+	Type string // "string", "number", or "bool"
+}
+
+// ToolSource is the single implementation source of a tool.
+type ToolSource struct {
+	Kind string // mcp | http | builtin | runtime | script
+	URI  string // required for mcp/http/script, empty for builtin/runtime
+}


### PR DESCRIPTION
- schema.Tool/ToolParam/ToolReturns/ToolSource + parser.ParseToolFile
- Types are bare keywords (string | number | bool) resolved via hcl.ExprAsKeyword; defaults are type-checked against the declared type, explicit null rejected
- Exactly one source and returns block enforced with address-prefixed errors; kind is a closed enum; uri required for mcp/http/script, forbidden for builtin/runtime
- Codify tool rules in SPEC.md 3.3