### PR TITLE
Parse .agent files: unresolved refs, IO contract, depends_on (#3)

### DIFF
--- a/internal/parser/agent.go
+++ b/internal/parser/agent.go
@@ -1,0 +1,299 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
+
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+type agentFileHCL struct {
+	Agents []agentHCL `hcl:"agent,block"`
+}
+
+// agentHCL keeps reference-valued attributes as raw expressions: references
+// like model.fast are scope traversals, not string values, and must not be
+// evaluated at parse time.
+type agentHCL struct {
+	Label        string           `hcl:"name,label"`
+	Description  *string          `hcl:"description"`
+	Model        hcl.Expression   `hcl:"model"`
+	SystemPrompt hcl.Expression   `hcl:"system_prompt"`
+	Tools        hcl.Expression   `hcl:"tools,optional"`
+	Inputs       []agentInputHCL  `hcl:"input,block"`
+	Outputs      []agentOutputHCL `hcl:"output,block"`
+	DependsOn    hcl.Expression   `hcl:"depends_on,optional"`
+}
+
+// agentInputHCL keeps default as a raw expression because it may be either a
+// literal or an agent output reference.
+type agentInputHCL struct {
+	Label       string         `hcl:"name,label"`
+	Type        hcl.Expression `hcl:"type"`
+	Description *string        `hcl:"description"`
+	Optional    *bool          `hcl:"optional"`
+	Default     hcl.Expression `hcl:"default,optional"`
+}
+
+type agentOutputHCL struct {
+	Label       string         `hcl:"name,label"`
+	Type        hcl.Expression `hcl:"type"`
+	Description *string        `hcl:"description"`
+}
+
+// ParseAgentFile reads and decodes an agent file (.agent).
+func ParseAgentFile(path string) ([]*schema.Agent, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading agent file: %w", err)
+	}
+	return ParseAgents(path, src)
+}
+
+// ParseAgents decodes agent file source. filename is used in diagnostics.
+func ParseAgents(filename string, src []byte) ([]*schema.Agent, error) {
+	file, diags := hclparse.NewParser().ParseHCL(src, filename)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	var raw agentFileHCL
+	if diags := gohcl.DecodeBody(file.Body, nil, &raw); diags.HasErrors() {
+		return nil, diags
+	}
+
+	var agents []*schema.Agent
+	seen := map[string]bool{}
+	for _, a := range raw.Agents {
+		agent, err := decodeAgent(a)
+		if err != nil {
+			return nil, err
+		}
+		if seen[agent.Name] {
+			return nil, fmt.Errorf("%s: declared more than once", agent.Addr())
+		}
+		seen[agent.Name] = true
+		agents = append(agents, agent)
+	}
+	return agents, nil
+}
+
+func decodeAgent(a agentHCL) (*schema.Agent, error) {
+	agent := &schema.Agent{Name: a.Label}
+	if a.Description != nil {
+		agent.Description = *a.Description
+	}
+
+	model, err := requiredRef(agent.Addr(), "model", "model", a.Model)
+	if err != nil {
+		return nil, err
+	}
+	agent.Model = model
+
+	systemPrompt, err := requiredRef(agent.Addr(), "system_prompt", "prompt", a.SystemPrompt)
+	if err != nil {
+		return nil, err
+	}
+	agent.SystemPrompt = systemPrompt
+
+	tools, err := refList(agent.Addr(), "tools", "tool", a.Tools)
+	if err != nil {
+		return nil, err
+	}
+	agent.Tools = tools
+
+	dependsOn, err := refList(agent.Addr(), "depends_on", "agent", a.DependsOn)
+	if err != nil {
+		return nil, err
+	}
+	agent.DependsOn = dependsOn
+
+	seenIO := map[string]bool{}
+	for _, in := range a.Inputs {
+		input, err := decodeAgentInput(agent.Addr(), in)
+		if err != nil {
+			return nil, err
+		}
+		if seenIO[input.Name] {
+			return nil, fmt.Errorf("%s: input %q declared more than once", agent.Addr(), input.Name)
+		}
+		seenIO[input.Name] = true
+		agent.Inputs = append(agent.Inputs, input)
+	}
+
+	seenOutputs := map[string]bool{}
+	for _, out := range a.Outputs {
+		output, err := decodeAgentOutput(agent.Addr(), out)
+		if err != nil {
+			return nil, err
+		}
+		if seenOutputs[output.Name] {
+			return nil, fmt.Errorf("%s: output %q declared more than once", agent.Addr(), output.Name)
+		}
+		if seenIO[output.Name] {
+			return nil, fmt.Errorf("%s: %q declared as both input and output", agent.Addr(), output.Name)
+		}
+		seenOutputs[output.Name] = true
+		agent.Outputs = append(agent.Outputs, output)
+	}
+
+	return agent, nil
+}
+
+func decodeAgentInput(agentAddr string, in agentInputHCL) (*schema.AgentInput, error) {
+	addr := fmt.Sprintf("%s: input %q", agentAddr, in.Label)
+
+	input := &schema.AgentInput{Name: in.Label}
+	if in.Description != nil {
+		input.Description = *in.Description
+	}
+	if in.Optional != nil {
+		input.Optional = *in.Optional
+	}
+
+	typ, err := typeKeyword(addr, in.Type)
+	if err != nil {
+		return nil, err
+	}
+	input.Type = typ
+
+	if !absentExpr(in.Default) {
+		// Literal first: bare null/true/false parse as single-step traversals
+		// too, so evaluation is the reliable literal test.
+		if val, diags := in.Default.Value(nil); !diags.HasErrors() {
+			if val.IsNull() {
+				return nil, fmt.Errorf("%s: default cannot be null; omit the attribute instead", addr)
+			}
+			if want := paramTypes[typ]; val.Type() != want {
+				return nil, fmt.Errorf("%s: default must be %s, got %s", addr, typ, val.Type().FriendlyName())
+			}
+			goVal, err := ctyToGo(val)
+			if err != nil {
+				return nil, fmt.Errorf("%s: default: %w", addr, err)
+			}
+			input.Default = goVal
+			return input, nil
+		}
+
+		parts, ok := traversalParts(in.Default)
+		if !ok {
+			return nil, fmt.Errorf("%s: default must be a literal or a reference like agent.<name>.output.<name>", addr)
+		}
+		if len(parts) != 4 || parts[0] != "agent" || parts[2] != "output" {
+			return nil, fmt.Errorf("%s: default must be a literal or a reference like agent.<name>.output.<name>, got %q", addr, strings.Join(parts, "."))
+		}
+		input.DefaultRef = strings.Join(parts, ".")
+	}
+
+	return input, nil
+}
+
+func decodeAgentOutput(agentAddr string, out agentOutputHCL) (*schema.AgentOutput, error) {
+	addr := fmt.Sprintf("%s: output %q", agentAddr, out.Label)
+
+	output := &schema.AgentOutput{Name: out.Label}
+	if out.Description != nil {
+		output.Description = *out.Description
+	}
+
+	typ, err := typeKeyword(addr, out.Type)
+	if err != nil {
+		return nil, err
+	}
+	output.Type = typ
+
+	return output, nil
+}
+
+// requiredRef decodes an attribute that must be present and hold a reference
+// of the form <root>.<name>.
+func requiredRef(addr, attr, root string, expr hcl.Expression) (string, error) {
+	if absentExpr(expr) {
+		return "", fmt.Errorf("%s: missing required attribute %q", addr, attr)
+	}
+	return simpleRef(addr, attr, root, expr)
+}
+
+// simpleRef decodes an expression that must be a reference of the form
+// <root>.<name> and returns it as an unresolved address string.
+func simpleRef(addr, attr, root string, expr hcl.Expression) (string, error) {
+	parts, ok := traversalParts(expr)
+	if !ok {
+		return "", fmt.Errorf("%s: %s must be a reference like %s.<name>", addr, attr, root)
+	}
+	if len(parts) != 2 || parts[0] != root {
+		return "", fmt.Errorf("%s: %s must be a reference like %s.<name>, got %q", addr, attr, root, strings.Join(parts, "."))
+	}
+	return parts[0] + "." + parts[1], nil
+}
+
+// refList decodes an optional list attribute whose elements must all be
+// references of the form <root>.<name>. A nil expression (attribute absent)
+// yields a nil slice.
+func refList(addr, attr, root string, expr hcl.Expression) ([]string, error) {
+	if absentExpr(expr) {
+		return nil, nil
+	}
+
+	elems, diags := hcl.ExprList(expr)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("%s: %s must be a list of %s references", addr, attr, root)
+	}
+
+	var refs []string
+	seen := map[string]bool{}
+	for _, elem := range elems {
+		ref, err := simpleRef(addr, attr+" element", root, elem)
+		if err != nil {
+			return nil, err
+		}
+		if seen[ref] {
+			return nil, fmt.Errorf("%s: %s: %q listed more than once", addr, attr, ref)
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+// absentExpr reports whether an expression attribute was omitted in source.
+// gohcl fills omitted expression fields with a synthetic null literal whose
+// range is zero-length, which distinguishes it from an explicit null.
+func absentExpr(expr hcl.Expression) bool {
+	if expr == nil {
+		return true
+	}
+	if !expr.Range().Empty() {
+		return false
+	}
+	val, diags := expr.Value(nil)
+	return !diags.HasErrors() && val.IsNull()
+}
+
+// traversalParts flattens a reference expression like agent.forecast.output.summary
+// into its dotted parts. It reports false for anything that is not plain
+// attribute access (literals, strings, index steps).
+func traversalParts(expr hcl.Expression) ([]string, bool) {
+	trav, diags := hcl.AbsTraversalForExpr(expr)
+	if diags.HasErrors() {
+		return nil, false
+	}
+
+	parts := make([]string, 0, len(trav))
+	for _, step := range trav {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			parts = append(parts, s.Name)
+		case hcl.TraverseAttr:
+			parts = append(parts, s.Name)
+		default:
+			return nil, false
+		}
+	}
+	return parts, true
+}

--- a/internal/parser/agent_test.go
+++ b/internal/parser/agent_test.go
@@ -1,0 +1,203 @@
+package parser_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/parser"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+func TestParseAgentFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		want    []*schema.Agent
+		wantErr string // substring the error must contain; empty means no error
+	}{
+		{
+			name: "full agent with refs, tools, typed inputs and outputs, depends_on",
+			file: "valid_full.agent",
+			want: []*schema.Agent{
+				{
+					Name:         "weather",
+					Description:  "Answers weather questions for a location and date",
+					Model:        "model.fast",
+					SystemPrompt: "prompt.weather_system",
+					Tools:        []string{"tool.web_search", "tool.geocode"},
+					Inputs: []*schema.AgentInput{
+						{Name: "location", Type: "string", Description: "The location to get the weather for"},
+						{Name: "date", Type: "string", Optional: true},
+						{Name: "max_hops", Type: "number", Default: int64(3)},
+						{Name: "forecast_context", Type: "string", DefaultRef: "agent.forecast.output.summary"},
+					},
+					Outputs: []*schema.AgentOutput{
+						{Name: "weather", Type: "string", Description: "The weather report"},
+					},
+					DependsOn: []string{"agent.geocoder"},
+				},
+			},
+		},
+		{
+			name: "minimal agent needs only model and system_prompt",
+			file: "valid_minimal.agent",
+			want: []*schema.Agent{
+				{
+					Name:         "echo",
+					Model:        "model.fast",
+					SystemPrompt: "prompt.echo_system",
+				},
+			},
+		},
+		{
+			name: "multiple agents per file; output refs captured unresolved",
+			file: "valid_multi.agent",
+			want: []*schema.Agent{
+				{
+					Name:         "geocoder",
+					Model:        "model.fast",
+					SystemPrompt: "prompt.geocoder_system",
+					Inputs:       []*schema.AgentInput{{Name: "place", Type: "string"}},
+					Outputs:      []*schema.AgentOutput{{Name: "coordinates", Type: "string"}},
+				},
+				{
+					Name:         "forecast",
+					Model:        "model.smart",
+					SystemPrompt: "prompt.forecast_system",
+					Inputs: []*schema.AgentInput{
+						{Name: "coordinates", Type: "string", DefaultRef: "agent.geocoder.output.coordinates"},
+					},
+					Outputs: []*schema.AgentOutput{{Name: "summary", Type: "string"}},
+				},
+			},
+		},
+		{
+			name:    "duplicate agent names are rejected",
+			file:    "invalid_dup_agent.agent",
+			wantErr: `agent.weather: declared more than once`,
+		},
+		{
+			name:    "missing model is rejected",
+			file:    "invalid_missing_model.agent",
+			wantErr: `agent.weather: missing required attribute "model"`,
+		},
+		{
+			name:    "model referencing a non-model address is rejected",
+			file:    "invalid_model_ref_kind.agent",
+			wantErr: `agent.weather: model must be a reference like model.<name>, got "prompt.weather_system"`,
+		},
+		{
+			name:    "quoted string is not a model reference",
+			file:    "invalid_model_string.agent",
+			wantErr: `agent.weather: model must be a reference like model.<name>`,
+		},
+		{
+			name:    "system_prompt referencing a non-prompt address is rejected",
+			file:    "invalid_prompt_ref_kind.agent",
+			wantErr: `agent.weather: system_prompt must be a reference like prompt.<name>, got "tool.web_search"`,
+		},
+		{
+			name:    "tools must be a list",
+			file:    "invalid_tools_not_list.agent",
+			wantErr: `agent.weather: tools must be a list of tool references`,
+		},
+		{
+			name:    "tools element referencing a non-tool address is rejected",
+			file:    "invalid_tool_ref_kind.agent",
+			wantErr: `agent.weather: tools element must be a reference like tool.<name>, got "model.fast"`,
+		},
+		{
+			name:    "duplicate tool references are rejected",
+			file:    "invalid_dup_tool_ref.agent",
+			wantErr: `agent.weather: tools: "tool.web_search" listed more than once`,
+		},
+		{
+			name:    "duplicate input names are rejected",
+			file:    "invalid_dup_input.agent",
+			wantErr: `agent.weather: input "location" declared more than once`,
+		},
+		{
+			name:    "duplicate output names are rejected",
+			file:    "invalid_dup_output.agent",
+			wantErr: `agent.weather: output "weather" declared more than once`,
+		},
+		{
+			name:    "input and output sharing a name are rejected",
+			file:    "invalid_io_collision.agent",
+			wantErr: `agent.weather: "weather" declared as both input and output`,
+		},
+		{
+			name:    "input type outside the enum is rejected",
+			file:    "invalid_input_type.agent",
+			wantErr: `agent.weather: input "location": invalid type "integer" (expected string, number, or bool)`,
+		},
+		{
+			name:    "quoted output type is rejected, types are bare keywords",
+			file:    "invalid_output_type_quoted.agent",
+			wantErr: `agent.weather: output "weather": type must be a bare keyword (string, number, or bool)`,
+		},
+		{
+			name:    "literal default must match the declared input type",
+			file:    "invalid_default_type.agent",
+			wantErr: `agent.weather: input "location": default must be string, got number`,
+		},
+		{
+			name:    "null default is rejected",
+			file:    "invalid_default_null.agent",
+			wantErr: `agent.weather: input "location": default cannot be null; omit the attribute instead`,
+		},
+		{
+			name:    "default reference must be an agent output address",
+			file:    "invalid_default_ref_shape.agent",
+			wantErr: `agent.weather: input "forecast_context": default must be a literal or a reference like agent.<name>.output.<name>, got "agent.forecast.summary"`,
+		},
+		{
+			name:    "default reference to a non-agent address is rejected",
+			file:    "invalid_default_ref_kind.agent",
+			wantErr: `agent.weather: input "forecast_context": default must be a literal or a reference like agent.<name>.output.<name>, got "tool.web_search"`,
+		},
+		{
+			name:    "depends_on element referencing a non-agent address is rejected",
+			file:    "invalid_depends_on_kind.agent",
+			wantErr: `agent.weather: depends_on element must be a reference like agent.<name>, got "tool.web_search"`,
+		},
+		{
+			name:    "unknown attributes are rejected",
+			file:    "invalid_unknown_attr.agent",
+			wantErr: `Unsupported argument`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.ParseAgentFile(filepath.Join("testdata", tt.file))
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ParseAgentFile(%s) mismatch (-want +got):\n%s", tt.file, diff)
+			}
+		})
+	}
+}
+
+func TestParseAgentFile_MissingFile(t *testing.T) {
+	_, err := parser.ParseAgentFile(filepath.Join("testdata", "does_not_exist.agent"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/parser/testdata/invalid_default_null.agent
+++ b/internal/parser/testdata/invalid_default_null.agent
@@ -1,0 +1,9 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "location" {
+    type    = string
+    default = null
+  }
+}

--- a/internal/parser/testdata/invalid_default_ref_kind.agent
+++ b/internal/parser/testdata/invalid_default_ref_kind.agent
@@ -1,0 +1,9 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "forecast_context" {
+    type    = string
+    default = tool.web_search
+  }
+}

--- a/internal/parser/testdata/invalid_default_ref_shape.agent
+++ b/internal/parser/testdata/invalid_default_ref_shape.agent
@@ -1,0 +1,9 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "forecast_context" {
+    type    = string
+    default = agent.forecast.summary
+  }
+}

--- a/internal/parser/testdata/invalid_default_type.agent
+++ b/internal/parser/testdata/invalid_default_type.agent
@@ -1,0 +1,9 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "location" {
+    type    = string
+    default = 42
+  }
+}

--- a/internal/parser/testdata/invalid_depends_on_kind.agent
+++ b/internal/parser/testdata/invalid_depends_on_kind.agent
@@ -1,0 +1,5 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+  depends_on    = [tool.web_search]
+}

--- a/internal/parser/testdata/invalid_dup_agent.agent
+++ b/internal/parser/testdata/invalid_dup_agent.agent
@@ -1,0 +1,9 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+}
+
+agent "weather" {
+  model         = model.smart
+  system_prompt = prompt.weather_system
+}

--- a/internal/parser/testdata/invalid_dup_input.agent
+++ b/internal/parser/testdata/invalid_dup_input.agent
@@ -1,0 +1,12 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "location" {
+    type = string
+  }
+
+  input "location" {
+    type = number
+  }
+}

--- a/internal/parser/testdata/invalid_dup_output.agent
+++ b/internal/parser/testdata/invalid_dup_output.agent
@@ -1,0 +1,12 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  output "weather" {
+    type = string
+  }
+
+  output "weather" {
+    type = string
+  }
+}

--- a/internal/parser/testdata/invalid_dup_tool_ref.agent
+++ b/internal/parser/testdata/invalid_dup_tool_ref.agent
@@ -1,0 +1,5 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+  tools         = [tool.web_search, tool.web_search]
+}

--- a/internal/parser/testdata/invalid_input_type.agent
+++ b/internal/parser/testdata/invalid_input_type.agent
@@ -1,0 +1,8 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "location" {
+    type = integer
+  }
+}

--- a/internal/parser/testdata/invalid_io_collision.agent
+++ b/internal/parser/testdata/invalid_io_collision.agent
@@ -1,0 +1,12 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  input "weather" {
+    type = string
+  }
+
+  output "weather" {
+    type = string
+  }
+}

--- a/internal/parser/testdata/invalid_missing_model.agent
+++ b/internal/parser/testdata/invalid_missing_model.agent
@@ -1,0 +1,3 @@
+agent "weather" {
+  system_prompt = prompt.weather_system
+}

--- a/internal/parser/testdata/invalid_model_ref_kind.agent
+++ b/internal/parser/testdata/invalid_model_ref_kind.agent
@@ -1,0 +1,4 @@
+agent "weather" {
+  model         = prompt.weather_system
+  system_prompt = prompt.weather_system
+}

--- a/internal/parser/testdata/invalid_model_string.agent
+++ b/internal/parser/testdata/invalid_model_string.agent
@@ -1,0 +1,4 @@
+agent "weather" {
+  model         = "model.fast"
+  system_prompt = prompt.weather_system
+}

--- a/internal/parser/testdata/invalid_output_type_quoted.agent
+++ b/internal/parser/testdata/invalid_output_type_quoted.agent
@@ -1,0 +1,8 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  output "weather" {
+    type = "string"
+  }
+}

--- a/internal/parser/testdata/invalid_prompt_ref_kind.agent
+++ b/internal/parser/testdata/invalid_prompt_ref_kind.agent
@@ -1,0 +1,4 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = tool.web_search
+}

--- a/internal/parser/testdata/invalid_tool_ref_kind.agent
+++ b/internal/parser/testdata/invalid_tool_ref_kind.agent
@@ -1,0 +1,5 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+  tools         = [tool.web_search, model.fast]
+}

--- a/internal/parser/testdata/invalid_tools_not_list.agent
+++ b/internal/parser/testdata/invalid_tools_not_list.agent
@@ -1,0 +1,5 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+  tools         = tool.web_search
+}

--- a/internal/parser/testdata/invalid_unknown_attr.agent
+++ b/internal/parser/testdata/invalid_unknown_attr.agent
@@ -1,0 +1,5 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+  temperature   = 0.2
+}

--- a/internal/parser/testdata/valid_full.agent
+++ b/internal/parser/testdata/valid_full.agent
@@ -1,0 +1,37 @@
+agent "weather" {
+  description = "Answers weather questions for a location and date"
+
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  tools = [tool.web_search, tool.geocode]
+
+  input "location" {
+    type        = string
+    description = "The location to get the weather for"
+  }
+
+  input "date" {
+    type     = string
+    optional = true
+  }
+
+  input "max_hops" {
+    type    = number
+    default = 3
+  }
+
+  # Implicit dependency: created because we reference agent.forecast
+  input "forecast_context" {
+    type    = string
+    default = agent.forecast.output.summary
+  }
+
+  output "weather" {
+    type        = string
+    description = "The weather report"
+  }
+
+  # Explicit fallback when no reference exists (rare)
+  depends_on = [agent.geocoder]
+}

--- a/internal/parser/testdata/valid_minimal.agent
+++ b/internal/parser/testdata/valid_minimal.agent
@@ -1,0 +1,4 @@
+agent "echo" {
+  model         = model.fast
+  system_prompt = prompt.echo_system
+}

--- a/internal/parser/testdata/valid_multi.agent
+++ b/internal/parser/testdata/valid_multi.agent
@@ -1,0 +1,26 @@
+agent "geocoder" {
+  model         = model.fast
+  system_prompt = prompt.geocoder_system
+
+  input "place" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}
+
+agent "forecast" {
+  model         = model.smart
+  system_prompt = prompt.forecast_system
+
+  input "coordinates" {
+    type    = string
+    default = agent.geocoder.output.coordinates
+  }
+
+  output "summary" {
+    type = string
+  }
+}

--- a/internal/schema/agent.go
+++ b/internal/schema/agent.go
@@ -1,0 +1,35 @@
+package schema
+
+// Agent is a declarative agent definition decoded from a .agent file
+// (SPEC.md §3.2). All references are captured as unresolved block addresses
+// (e.g. "model.fast"); resolution against the module is a later pass.
+type Agent struct {
+	Name         string // block label, e.g. "weather" in agent.weather
+	Description  string // optional
+	Model        string // required reference, "model.<name>"
+	SystemPrompt string // required reference, "prompt.<name>"
+	Tools        []string
+	Inputs       []*AgentInput
+	Outputs      []*AgentOutput
+	DependsOn    []string
+}
+
+// Addr returns the block address used in references and diagnostics.
+func (a *Agent) Addr() string { return "agent." + a.Name }
+
+// AgentInput is one declared input of an agent's IO contract.
+type AgentInput struct {
+	Name        string
+	Type        string // "string", "number", or "bool"
+	Description string // optional
+	Optional    bool
+	Default     any    // literal default; nil when absent or when DefaultRef is set
+	DefaultRef  string // unresolved "agent.<name>.output.<name>" reference; empty otherwise
+}
+
+// AgentOutput is one declared output of an agent's IO contract.
+type AgentOutput struct {
+	Name        string
+	Type        string // "string", "number", or "bool"
+	Description string // optional
+}


### PR DESCRIPTION
agent block decoding per SPEC.md §3.2: description, required model and system_prompt references, tools list, typed input/output blocks (type/description/optional/default), and depends_on.

References (model.x, prompt.x, tool.x, agent.x.output.y) are captured as unresolved address strings; resolution is issue #6. Input defaults may be a literal (type-checked at parse time, same rule as tool params) or an agent output reference.