### PR TITLE
Module loading: symbol table + cross-file reference resolution (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ Agentform is "Terraform for AI agents": a declarative HCL spec compiled to agent
 cmd/adl/            CLI entrypoint (cobra)
 internal/
   parser/           HCL decode (hashicorp/hcl/v2) → AST
-  schema/           typed config structs, validation, reference resolution
+  schema/           typed config structs, validation
+  module/           directory walk → symbol table, cross-file reference resolution
   graph/            DAG construction, cycle detection, topo sort
   build/            codegen engine + per-target generators (build/langgraph/)
   provider/         platform reconcilers (provider/openai/)

--- a/SPEC.md
+++ b/SPEC.md
@@ -230,7 +230,8 @@ State file (`adl.state.json`): maps block addresses → remote resource IDs, tra
 cmd/adl/            CLI (cobra)
 internal/
   parser/           HCL decode (hashicorp/hcl/v2) → AST
-  schema/           typed config structs, validation, reference resolution
+  schema/           typed config structs, validation
+  module/           directory walk → symbol table, cross-file reference resolution
   graph/            DAG construction, cycle detection, topo sort
   build/            codegen engine
     langgraph/      target: LangGraph (Python)

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -1,0 +1,227 @@
+// Package module loads every ADL file in a directory tree into one module
+// (SPEC.md §2), builds the module-wide symbol table, and resolves all
+// captured references against it. Reference shapes and kinds are validated
+// at parse time; this pass only checks that every target exists.
+package module
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/weirdGuy/agentform/internal/parser"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+// Module is a fully loaded and reference-resolved directory tree of ADL
+// files. Block slices follow lexical file order, source order within a file,
+// so downstream output stays deterministic.
+type Module struct {
+	Root    string
+	Agents  []*schema.Agent
+	Tools   []*schema.Tool
+	Prompts []*schema.Prompt
+	Models  []*schema.Model
+	Targets []*schema.Target
+
+	symbols map[string]*Symbol
+}
+
+// Symbol is one addressable block in the module's symbol table.
+type Symbol struct {
+	Addr  string // block address, e.g. "agent.weather"
+	Kind  string // agent | tool | prompt | model | target
+	File  string // declaring file, relative to the module root
+	Block any    // *schema.Agent, *schema.Tool, *schema.Prompt, *schema.Model, or *schema.Target
+}
+
+// Lookup resolves a block address against the module's symbol table.
+func (m *Module) Lookup(addr string) (*Symbol, bool) {
+	sym, ok := m.symbols[addr]
+	return sym, ok
+}
+
+// Load walks the directory tree rooted at root, parses every ADL file
+// (.agent, .tool, .prompt, .adl, adl.hcl), and resolves all references.
+// Hidden files and directories (dot-prefixed) are skipped. All errors —
+// parse failures, cross-file duplicate addresses, unknown references — are
+// collected and returned joined, so one run reports everything.
+func Load(root string) (*Module, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("loading module: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("loading module: %s is not a directory", root)
+	}
+
+	mod := &Module{Root: root, symbols: map[string]*Symbol{}}
+
+	var errs []error
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		hidden := strings.HasPrefix(d.Name(), ".") && path != root
+		if d.IsDir() {
+			if hidden {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if hidden {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		errs = append(errs, mod.loadFile(path, rel)...)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walking module directory: %w", walkErr)
+	}
+
+	for _, a := range mod.Agents {
+		errs = append(errs, mod.resolveAgent(a)...)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	return mod, nil
+}
+
+// loadFile parses one ADL file (dispatched on its name) and registers its
+// blocks. Files with other extensions are ignored. A duplicate address skips
+// that block but keeps registering the rest of the file.
+func (m *Module) loadFile(path, rel string) []error {
+	var errs []error
+	define := func(kind, addr string, block any) bool {
+		if prev, taken := m.symbols[addr]; taken {
+			errs = append(errs, fmt.Errorf("%s: declared in both %s and %s", addr, prev.File, rel))
+			return false
+		}
+		m.symbols[addr] = &Symbol{Addr: addr, Kind: kind, File: rel, Block: block}
+		return true
+	}
+
+	switch filepath.Ext(path) {
+	case ".agent":
+		agents, err := parser.ParseAgentFile(path)
+		if err != nil {
+			return []error{fileErr(rel, err)}
+		}
+		for _, a := range agents {
+			if define("agent", a.Addr(), a) {
+				m.Agents = append(m.Agents, a)
+			}
+		}
+	case ".tool":
+		tools, err := parser.ParseToolFile(path)
+		if err != nil {
+			return []error{fileErr(rel, err)}
+		}
+		for _, t := range tools {
+			if define("tool", t.Addr(), t) {
+				m.Tools = append(m.Tools, t)
+			}
+		}
+	case ".prompt":
+		prompt, err := parser.ParsePromptFile(path)
+		if err != nil {
+			return []error{fileErr(rel, err)}
+		}
+		if define("prompt", prompt.Addr(), prompt) {
+			m.Prompts = append(m.Prompts, prompt)
+		}
+	case ".adl", ".hcl":
+		if filepath.Ext(path) == ".hcl" && filepath.Base(path) != "adl.hcl" {
+			return nil
+		}
+		project, err := parser.ParseProjectFile(path)
+		if err != nil {
+			return []error{fileErr(rel, err)}
+		}
+		for _, mdl := range project.Models {
+			if define("model", mdl.Addr(), mdl) {
+				m.Models = append(m.Models, mdl)
+			}
+		}
+		for _, tgt := range project.Targets {
+			if define("target", tgt.Addr(), tgt) {
+				m.Targets = append(m.Targets, tgt)
+			}
+		}
+	}
+	return errs
+}
+
+// resolveAgent checks every reference captured on an agent against the
+// symbol table. Reference kinds are guaranteed by the parser (model.* for
+// model, etc.), so existence is the only question left.
+func (m *Module) resolveAgent(a *schema.Agent) []error {
+	file := m.symbols[a.Addr()].File
+
+	var errs []error
+	check := func(ref string) {
+		if _, ok := m.symbols[ref]; !ok {
+			errs = append(errs, fmt.Errorf("%s: %s: unknown reference %s", file, a.Addr(), ref))
+		}
+	}
+
+	check(a.Model)
+	check(a.SystemPrompt)
+	for _, ref := range a.Tools {
+		check(ref)
+	}
+	for _, ref := range a.DependsOn {
+		check(ref)
+	}
+
+	for _, in := range a.Inputs {
+		if in.DefaultRef == "" {
+			continue
+		}
+		// Parser guarantees the shape agent.<name>.output.<name>.
+		parts := strings.SplitN(in.DefaultRef, ".", 4)
+		agentAddr, outName := parts[0]+"."+parts[1], parts[3]
+
+		sym, ok := m.symbols[agentAddr]
+		if !ok {
+			errs = append(errs, fmt.Errorf("%s: %s: input %q: unknown reference %s", file, a.Addr(), in.Name, in.DefaultRef))
+			continue
+		}
+		target := sym.Block.(*schema.Agent)
+		if !hasOutput(target, outName) {
+			errs = append(errs, fmt.Errorf("%s: %s: input %q: %s has no output %q", file, a.Addr(), in.Name, agentAddr, outName))
+		}
+	}
+	return errs
+}
+
+func hasOutput(a *schema.Agent, name string) bool {
+	for _, out := range a.Outputs {
+		if out.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// fileErr prefixes a parse error with the file it came from, unless it is an
+// HCL diagnostic set, which already carries filename and position.
+func fileErr(rel string, err error) error {
+	var diags hcl.Diagnostics
+	if errors.As(err, &diags) {
+		return err
+	}
+	return fmt.Errorf("%s: %w", rel, err)
+}

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -1,0 +1,192 @@
+package module_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/module"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+func TestLoadValidModule(t *testing.T) {
+	mod, err := module.Load(filepath.Join("testdata", "valid_module"))
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+
+	// Blocks appear in lexical file-walk order, source order within a file.
+	wantAgents := []string{"agent.geocoder", "agent.forecast", "agent.weather"}
+	if diff := cmp.Diff(wantAgents, agentAddrs(mod.Agents)); diff != "" {
+		t.Errorf("agents (-want +got):\n%s", diff)
+	}
+	wantModels := []string{"model.fast", "model.smart"}
+	if diff := cmp.Diff(wantModels, modelAddrs(mod.Models)); diff != "" {
+		t.Errorf("models (-want +got):\n%s", diff)
+	}
+	wantPrompts := []string{"prompt.forecast_system", "prompt.geocoder_system", "prompt.weather_system"}
+	if diff := cmp.Diff(wantPrompts, promptAddrs(mod.Prompts)); diff != "" {
+		t.Errorf("prompts (-want +got):\n%s", diff)
+	}
+	wantTools := []string{"tool.web_search"}
+	if diff := cmp.Diff(wantTools, toolAddrs(mod.Tools)); diff != "" {
+		t.Errorf("tools (-want +got):\n%s", diff)
+	}
+	wantTargets := []string{"target.langgraph"}
+	if diff := cmp.Diff(wantTargets, targetAddrs(mod.Targets)); diff != "" {
+		t.Errorf("targets (-want +got):\n%s", diff)
+	}
+
+	sym, ok := mod.Lookup("agent.forecast")
+	if !ok {
+		t.Fatal(`Lookup("agent.forecast") not found`)
+	}
+	if sym.Kind != "agent" {
+		t.Errorf("Lookup kind = %q, want %q", sym.Kind, "agent")
+	}
+	if want := filepath.Join("agents", "pipeline.agent"); sym.File != want {
+		t.Errorf("Lookup file = %q, want %q", sym.File, want)
+	}
+	if _, ok := sym.Block.(*schema.Agent); !ok {
+		t.Errorf("Lookup block type = %T, want *schema.Agent", sym.Block)
+	}
+
+	if _, ok := mod.Lookup("model.nope"); ok {
+		t.Error(`Lookup("model.nope") found, want missing`)
+	}
+}
+
+func TestLoadEmptyDir(t *testing.T) {
+	mod, err := module.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	if len(mod.Agents)+len(mod.Tools)+len(mod.Prompts)+len(mod.Models)+len(mod.Targets) != 0 {
+		t.Error("empty directory should load as an empty module")
+	}
+}
+
+func TestLoadMissingDir(t *testing.T) {
+	if _, err := module.Load(filepath.Join("testdata", "does_not_exist")); err == nil {
+		t.Fatal("Load: expected error for missing directory")
+	}
+}
+
+func TestLoadRootMustBeDirectory(t *testing.T) {
+	root := filepath.Join("testdata", "valid_module", "adl.hcl")
+	_, err := module.Load(root)
+	if err == nil {
+		t.Fatal("Load: expected error for file as module root")
+	}
+	if want := "not a directory"; !strings.Contains(err.Error(), want) {
+		t.Errorf("Load error = %q, want substring %q", err, want)
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		wantErrs []string // substrings the error must contain
+	}{
+		{
+			name: "unknown model and tool references are all reported",
+			dir:  "unknown_refs",
+			wantErrs: []string{
+				`solo.agent: agent.solo: unknown reference model.missing`,
+				`solo.agent: agent.solo: unknown reference tool.missing`,
+			},
+		},
+		{
+			name: "output reference to a missing output names the agent",
+			dir:  "unknown_output",
+			wantErrs: []string{
+				`pair.agent: agent.b: input "ctx": agent.a has no output "y"`,
+			},
+		},
+		{
+			name: "depends_on referencing an unknown agent",
+			dir:  "unknown_dep",
+			wantErrs: []string{
+				`lonely.agent: agent.lonely: unknown reference agent.ghost`,
+			},
+		},
+		{
+			name: "agent declared in two files",
+			dir:  "dup_agent",
+			wantErrs: []string{
+				`agent.weather: declared in both first.agent and second.agent`,
+			},
+		},
+		{
+			name: "model declared in two project files, including .adl extension",
+			dir:  "dup_model",
+			wantErrs: []string{
+				`model.fast: declared in both adl.hcl and extra.adl`,
+			},
+		},
+		{
+			name: "parse errors carry the offending file name",
+			dir:  "parse_error",
+			wantErrs: []string{
+				`bad.agent`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := module.Load(filepath.Join("testdata", tc.dir))
+			if err == nil {
+				t.Fatalf("Load: expected error containing %q, got nil", tc.wantErrs)
+			}
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Load error = %q\nwant substring %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func agentAddrs(agents []*schema.Agent) []string {
+	addrs := make([]string, len(agents))
+	for i, a := range agents {
+		addrs[i] = a.Addr()
+	}
+	return addrs
+}
+
+func modelAddrs(models []*schema.Model) []string {
+	addrs := make([]string, len(models))
+	for i, m := range models {
+		addrs[i] = m.Addr()
+	}
+	return addrs
+}
+
+func promptAddrs(prompts []*schema.Prompt) []string {
+	addrs := make([]string, len(prompts))
+	for i, p := range prompts {
+		addrs[i] = p.Addr()
+	}
+	return addrs
+}
+
+func toolAddrs(tools []*schema.Tool) []string {
+	addrs := make([]string, len(tools))
+	for i, tl := range tools {
+		addrs[i] = tl.Addr()
+	}
+	return addrs
+}
+
+func targetAddrs(targets []*schema.Target) []string {
+	addrs := make([]string, len(targets))
+	for i, tg := range targets {
+		addrs[i] = tg.Addr()
+	}
+	return addrs
+}

--- a/internal/module/testdata/dup_agent/adl.hcl
+++ b/internal/module/testdata/dup_agent/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/module/testdata/dup_agent/first.agent
+++ b/internal/module/testdata/dup_agent/first.agent
@@ -1,0 +1,4 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+}

--- a/internal/module/testdata/dup_agent/second.agent
+++ b/internal/module/testdata/dup_agent/second.agent
@@ -1,0 +1,4 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+}

--- a/internal/module/testdata/dup_agent/weather_system.prompt
+++ b/internal/module/testdata/dup_agent/weather_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "weather_system"
+---
+You are a weather assistant.

--- a/internal/module/testdata/dup_model/adl.hcl
+++ b/internal/module/testdata/dup_model/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/module/testdata/dup_model/extra.adl
+++ b/internal/module/testdata/dup_model/extra.adl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "anthropic"
+  id       = "claude-sonnet-5"
+}

--- a/internal/module/testdata/parse_error/bad.agent
+++ b/internal/module/testdata/parse_error/bad.agent
@@ -1,0 +1,2 @@
+agent "broken" {
+  model = model.fast

--- a/internal/module/testdata/unknown_dep/adl.hcl
+++ b/internal/module/testdata/unknown_dep/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/module/testdata/unknown_dep/lonely.agent
+++ b/internal/module/testdata/unknown_dep/lonely.agent
@@ -1,0 +1,6 @@
+agent "lonely" {
+  model         = model.fast
+  system_prompt = prompt.lonely_system
+
+  depends_on = [agent.ghost]
+}

--- a/internal/module/testdata/unknown_dep/lonely_system.prompt
+++ b/internal/module/testdata/unknown_dep/lonely_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "lonely_system"
+---
+You are lonely.

--- a/internal/module/testdata/unknown_output/adl.hcl
+++ b/internal/module/testdata/unknown_output/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/module/testdata/unknown_output/pair.agent
+++ b/internal/module/testdata/unknown_output/pair.agent
@@ -1,0 +1,18 @@
+agent "a" {
+  model         = model.fast
+  system_prompt = prompt.shared
+
+  output "x" {
+    type = string
+  }
+}
+
+agent "b" {
+  model         = model.fast
+  system_prompt = prompt.shared
+
+  input "ctx" {
+    type    = string
+    default = agent.a.output.y
+  }
+}

--- a/internal/module/testdata/unknown_output/shared.prompt
+++ b/internal/module/testdata/unknown_output/shared.prompt
@@ -1,0 +1,4 @@
+---
+name = "shared"
+---
+Shared system prompt.

--- a/internal/module/testdata/unknown_refs/solo.agent
+++ b/internal/module/testdata/unknown_refs/solo.agent
@@ -1,0 +1,6 @@
+agent "solo" {
+  model         = model.missing
+  system_prompt = prompt.solo_system
+
+  tools = [tool.missing]
+}

--- a/internal/module/testdata/unknown_refs/solo_system.prompt
+++ b/internal/module/testdata/unknown_refs/solo_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "solo_system"
+---
+You are solo.

--- a/internal/module/testdata/valid_module/.hidden/broken.agent
+++ b/internal/module/testdata/valid_module/.hidden/broken.agent
@@ -1,0 +1,2 @@
+this is not valid HCL {{{ and must never be parsed because hidden
+directories are skipped during module loading

--- a/internal/module/testdata/valid_module/adl.hcl
+++ b/internal/module/testdata/valid_module/adl.hcl
@@ -1,0 +1,14 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+model "smart" {
+  provider = "anthropic"
+  id       = "claude-sonnet-5"
+}
+
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+}

--- a/internal/module/testdata/valid_module/agents/pipeline.agent
+++ b/internal/module/testdata/valid_module/agents/pipeline.agent
@@ -1,0 +1,26 @@
+agent "geocoder" {
+  model         = model.fast
+  system_prompt = prompt.geocoder_system
+
+  input "place" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}
+
+agent "forecast" {
+  model         = model.smart
+  system_prompt = prompt.forecast_system
+
+  input "coordinates" {
+    type    = string
+    default = agent.geocoder.output.coordinates
+  }
+
+  output "summary" {
+    type = string
+  }
+}

--- a/internal/module/testdata/valid_module/agents/weather.agent
+++ b/internal/module/testdata/valid_module/agents/weather.agent
@@ -1,0 +1,17 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  tools = [tool.web_search]
+
+  input "forecast_context" {
+    type    = string
+    default = agent.forecast.output.summary
+  }
+
+  output "report" {
+    type = string
+  }
+
+  depends_on = [agent.geocoder]
+}

--- a/internal/module/testdata/valid_module/prompts/forecast_system.prompt
+++ b/internal/module/testdata/valid_module/prompts/forecast_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "forecast_system"
+---
+Produce a forecast summary for the coordinates.

--- a/internal/module/testdata/valid_module/prompts/geocoder_system.prompt
+++ b/internal/module/testdata/valid_module/prompts/geocoder_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "geocoder_system"
+---
+Turn the place name into coordinates.

--- a/internal/module/testdata/valid_module/prompts/weather_system.prompt
+++ b/internal/module/testdata/valid_module/prompts/weather_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "weather_system"
+---
+You are a weather assistant.

--- a/internal/module/testdata/valid_module/tools.tool
+++ b/internal/module/testdata/valid_module/tools.tool
@@ -1,0 +1,15 @@
+tool "web_search" {
+  description = "Search the web"
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}


### PR DESCRIPTION
Add internal/module: Load walks a directory tree, parses all .agent / .tool / .prompt / .adl / adl.hcl files (skipping dot-prefixed entries), builds the module-wide symbol table, rejects cross-file duplicate addresses, and resolves every captured reference — model, system_prompt, tools, depends_on, and agent.<x>.output.<y> input defaults, including that the named output exists. All errors are collected and returned joined so one run reports everything, each prefixed with the declaring file and block address.

Move "reference resolution" from schema/ to the new module/ line in the SPEC.md and CLAUDE.md architecture trees: parser imports schema for the typed structs, so a loader in schema would create an import cycle.