### PR TITLE
Validation: prompt variables satisfiable from agent IO (#7)

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -166,7 +166,9 @@ func (m *Module) loadFile(path, rel string) []error {
 
 // resolveAgent checks every reference captured on an agent against the
 // symbol table. Reference kinds are guaranteed by the parser (model.* for
-// model, etc.), so existence is the only question left.
+// model, etc.), so existence is the only question left. Once the system
+// prompt resolves, its variables are validated against the agent's IO
+// contract.
 func (m *Module) resolveAgent(a *schema.Agent) []error {
 	file := m.symbols[a.Addr()].File
 
@@ -184,6 +186,15 @@ func (m *Module) resolveAgent(a *schema.Agent) []error {
 	}
 	for _, ref := range a.DependsOn {
 		check(ref)
+	}
+
+	// SPEC.md §3.2: every variable the system prompt requires must be
+	// satisfiable from the agent's inputs/outputs. Skipped when the prompt
+	// reference is unknown — that already produced its own error above.
+	if sym, ok := m.symbols[a.SystemPrompt]; ok {
+		for _, err := range schema.ValidatePromptVars(a, sym.Block.(*schema.Prompt)) {
+			errs = append(errs, fmt.Errorf("%s: %w", file, err))
+		}
 	}
 
 	for _, in := range a.Inputs {

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -114,6 +114,14 @@ func TestLoadErrors(t *testing.T) {
 			},
 		},
 		{
+			name: "unsatisfied prompt variables are all reported",
+			dir:  "unsatisfied_var",
+			wantErrs: []string{
+				`greeter.agent: agent.greeter: system_prompt prompt.greeter_system: variable "city" is not an input or output of the agent`,
+				`greeter.agent: agent.greeter: system_prompt prompt.greeter_system: variable "mood" is not an input or output of the agent`,
+			},
+		},
+		{
 			name: "agent declared in two files",
 			dir:  "dup_agent",
 			wantErrs: []string{

--- a/internal/module/testdata/unsatisfied_var/adl.hcl
+++ b/internal/module/testdata/unsatisfied_var/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/module/testdata/unsatisfied_var/greeter.agent
+++ b/internal/module/testdata/unsatisfied_var/greeter.agent
@@ -1,0 +1,12 @@
+agent "greeter" {
+  model         = model.fast
+  system_prompt = prompt.greeter_system
+
+  input "name" {
+    type = string
+  }
+
+  output "greeting" {
+    type = string
+  }
+}

--- a/internal/module/testdata/unsatisfied_var/greeter_system.prompt
+++ b/internal/module/testdata/unsatisfied_var/greeter_system.prompt
@@ -1,0 +1,5 @@
+---
+name = "greeter_system"
+requires = ["name", "city", "mood"]
+---
+Greet {{name}} from {{city}} in a {{mood}} way.

--- a/internal/module/testdata/valid_module/prompts/weather_system.prompt
+++ b/internal/module/testdata/valid_module/prompts/weather_system.prompt
@@ -1,4 +1,6 @@
 ---
 name = "weather_system"
+requires = ["forecast_context"]
 ---
-You are a weather assistant.
+You are a weather assistant. Use this forecast context:
+{{forecast_context}}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -1,0 +1,35 @@
+package schema
+
+import "fmt"
+
+// ValidatePromptVars enforces the ownership rule from SPEC.md §3.2: every
+// variable an agent's system prompt requires must be satisfiable from the
+// agent's inputs or outputs. A variable is satisfied by name; prompt
+// variables are untyped in v0, so there is no type check, and optional
+// inputs satisfy a variable like any other.
+//
+// The prompt's effective variable set is Vars (the {{var}} references in the
+// body): when frontmatter declares requires, the parser has already enforced
+// that it matches the body exactly, and when it is omitted the set is
+// inferred from the body.
+//
+// All unsatisfied variables are reported, one error each, in body order.
+// Errors name the agent, the prompt, and the variable; the caller adds file
+// context.
+func ValidatePromptVars(a *Agent, p *Prompt) []error {
+	satisfied := make(map[string]bool, len(a.Inputs)+len(a.Outputs))
+	for _, in := range a.Inputs {
+		satisfied[in.Name] = true
+	}
+	for _, out := range a.Outputs {
+		satisfied[out.Name] = true
+	}
+
+	var errs []error
+	for _, v := range p.Vars {
+		if !satisfied[v] {
+			errs = append(errs, fmt.Errorf("%s: system_prompt %s: variable %q is not an input or output of the agent", a.Addr(), p.Addr(), v))
+		}
+	}
+	return errs
+}

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -1,0 +1,89 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+func TestValidatePromptVars(t *testing.T) {
+	agent := &schema.Agent{
+		Name:         "weather",
+		Model:        "model.fast",
+		SystemPrompt: "prompt.weather_system",
+		Inputs: []*schema.AgentInput{
+			{Name: "location", Type: "string"},
+			{Name: "date", Type: "string", Optional: true},
+		},
+		Outputs: []*schema.AgentOutput{
+			{Name: "report", Type: "string"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		vars     []string // prompt body variables, in body order
+		wantErrs []string // exact error messages, in order; empty = valid
+	}{
+		{
+			name: "no variables is trivially satisfied",
+			vars: nil,
+		},
+		{
+			name: "variables satisfied by inputs",
+			vars: []string{"location", "date"},
+		},
+		{
+			name: "optional input satisfies a variable",
+			vars: []string{"date"},
+		},
+		{
+			name: "output satisfies a variable",
+			vars: []string{"report"},
+		},
+		{
+			name: "unsatisfied variable names agent, prompt, and variable",
+			vars: []string{"location", "city"},
+			wantErrs: []string{
+				`agent.weather: system_prompt prompt.weather_system: variable "city" is not an input or output of the agent`,
+			},
+		},
+		{
+			name: "all unsatisfied variables are reported in body order",
+			vars: []string{"city", "location", "mood"},
+			wantErrs: []string{
+				`agent.weather: system_prompt prompt.weather_system: variable "city" is not an input or output of the agent`,
+				`agent.weather: system_prompt prompt.weather_system: variable "mood" is not an input or output of the agent`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt := &schema.Prompt{Name: "weather_system", Vars: tc.vars}
+			var got []string
+			for _, err := range schema.ValidatePromptVars(agent, prompt) {
+				got = append(got, err.Error())
+			}
+			if diff := cmp.Diff(tc.wantErrs, got); diff != "" {
+				t.Errorf("ValidatePromptVars errors (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidatePromptVarsEmptyContract(t *testing.T) {
+	agent := &schema.Agent{Name: "bare", Model: "model.fast", SystemPrompt: "prompt.bare"}
+	prompt := &schema.Prompt{Name: "bare", Vars: []string{"anything"}}
+
+	errs := schema.ValidatePromptVars(agent, prompt)
+	if len(errs) != 1 {
+		t.Fatalf("ValidatePromptVars returned %d errors, want 1: %v", len(errs), errs)
+	}
+	want := `agent.bare: system_prompt prompt.bare: variable "anything" is not an input or output of the agent`
+	if errs[0].Error() != want {
+		t.Errorf("error = %q, want %q", errs[0], want)
+	}
+}


### PR DESCRIPTION
Every {{var}} in an agent's system prompt must name one of the agent's inputs or outputs (SPEC.md §3.2). schema.ValidatePromptVars is the pure check; module resolution invokes it once the prompt reference resolves and prefixes file context. All unsatisfied variables are batched, one diagnostic each, naming the agent, the prompt, and the variable.