### PR TITLE
Graph: DAG construction, cycle detection, deterministic topo sort (#8)

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1,0 +1,147 @@
+// Package graph builds the dependency DAG over a loaded module's blocks
+// (SPEC.md §4, §6): references and depends_on entries become edges, cycles
+// are compile errors, and a deterministic topological order is exposed for
+// build/apply consumption.
+package graph
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/weirdGuy/agentform/internal/module"
+)
+
+// Graph is the dependency graph over every block address in a module.
+type Graph struct {
+	deps  map[string][]string // addr → sorted, deduped direct dependencies
+	order []string            // topological order, dependencies first
+}
+
+// Build constructs the graph from a loaded, reference-resolved module.
+// References (SPEC.md §4) and depends_on entries both become edges; deep
+// references like agent.forecast.output.summary collapse to an edge on the
+// owning block (agent.forecast). Every cycle is a compile error naming its
+// full path.
+func Build(mod *module.Module) (*Graph, error) {
+	g := &Graph{deps: map[string][]string{}}
+
+	for _, m := range mod.Models {
+		g.deps[m.Addr()] = nil
+	}
+	for _, p := range mod.Prompts {
+		g.deps[p.Addr()] = nil
+	}
+	for _, t := range mod.Tools {
+		g.deps[t.Addr()] = nil
+	}
+	for _, t := range mod.Targets {
+		g.deps[t.Addr()] = nil
+	}
+	for _, a := range mod.Agents {
+		refs := []string{a.Model, a.SystemPrompt}
+		refs = append(refs, a.Tools...)
+		refs = append(refs, a.DependsOn...)
+		for _, in := range a.Inputs {
+			if in.DefaultRef != "" {
+				refs = append(refs, owner(in.DefaultRef))
+			}
+		}
+		g.deps[a.Addr()] = dedupSorted(refs)
+	}
+
+	if err := g.sortTopologically(); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// Order returns the deterministic topological order, dependencies first.
+// Ties break lexicographically by block address.
+func (g *Graph) Order() []string {
+	return g.order
+}
+
+// Dependencies returns the direct dependencies of a block address, sorted.
+func (g *Graph) Dependencies(addr string) []string {
+	return g.deps[addr]
+}
+
+// sortTopologically fills g.order via depth-first post-order, visiting roots
+// and edges in address order so the result is deterministic. Every distinct
+// cycle found on the way is reported; any cycle leaves g.order unset.
+func (g *Graph) sortTopologically() error {
+	nodes := make([]string, 0, len(g.deps))
+	for addr := range g.deps {
+		nodes = append(nodes, addr)
+	}
+	sort.Strings(nodes)
+
+	const (
+		unvisited = iota
+		onPath
+		done
+	)
+	state := map[string]int{}
+	var path []string
+	var order []string
+	var errs []error
+
+	var visit func(addr string)
+	visit = func(addr string) {
+		state[addr] = onPath
+		path = append(path, addr)
+		for _, dep := range g.deps[addr] {
+			switch state[dep] {
+			case unvisited:
+				visit(dep)
+			case onPath:
+				errs = append(errs, cycleErr(path, dep))
+			}
+		}
+		path = path[:len(path)-1]
+		state[addr] = done
+		order = append(order, addr)
+	}
+	for _, addr := range nodes {
+		if state[addr] == unvisited {
+			visit(addr)
+		}
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+	g.order = order
+	return nil
+}
+
+// cycleErr formats the cycle closed by the edge from the top of path back to
+// start, e.g. "dependency cycle: agent.a → agent.b → agent.a".
+func cycleErr(path []string, start string) error {
+	i := 0
+	for path[i] != start {
+		i++
+	}
+	cycle := append(append([]string{}, path[i:]...), start)
+	return fmt.Errorf("dependency cycle: %s", strings.Join(cycle, " → "))
+}
+
+// owner collapses a deep reference (agent.forecast.output.summary) to the
+// address of the block that owns it (agent.forecast).
+func owner(ref string) string {
+	parts := strings.SplitN(ref, ".", 3)
+	return parts[0] + "." + parts[1]
+}
+
+func dedupSorted(refs []string) []string {
+	sort.Strings(refs)
+	out := refs[:0]
+	for i, r := range refs {
+		if i == 0 || refs[i-1] != r {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -1,0 +1,144 @@
+package graph_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/graph"
+	"github.com/weirdGuy/agentform/internal/module"
+)
+
+func load(t *testing.T, dir string) *module.Module {
+	t.Helper()
+	mod, err := module.Load(filepath.Join("testdata", dir))
+	if err != nil {
+		t.Fatalf("Load(%s): unexpected error: %v", dir, err)
+	}
+	return mod
+}
+
+func TestBuildValid(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string
+		wantOrder []string
+		wantDeps  map[string][]string
+	}{
+		{
+			name: "linear chain of output references",
+			dir:  "linear_chain",
+			wantOrder: []string{
+				"model.m", "prompt.sys", "tool.t",
+				"agent.a", "agent.b", "agent.c",
+				"target.dev",
+			},
+			wantDeps: map[string][]string{
+				"agent.a":    {"model.m", "prompt.sys", "tool.t"},
+				"agent.b":    {"agent.a", "model.m", "prompt.sys"},
+				"agent.c":    {"agent.b", "model.m", "prompt.sys"},
+				"model.m":    nil,
+				"target.dev": nil,
+			},
+		},
+		{
+			name: "diamond joins both branches before the sink",
+			dir:  "diamond",
+			wantOrder: []string{
+				"model.m", "prompt.sys",
+				"agent.a", "agent.b", "agent.c", "agent.d",
+			},
+			wantDeps: map[string][]string{
+				"agent.d": {"agent.b", "agent.c", "model.m", "prompt.sys"},
+			},
+		},
+		{
+			name: "depends_on alone creates an ordering edge",
+			dir:  "depends_on_only",
+			wantOrder: []string{
+				"model.m", "prompt.sys",
+				"agent.a", "agent.b",
+			},
+			wantDeps: map[string][]string{
+				"agent.b": {"agent.a", "model.m", "prompt.sys"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := graph.Build(load(t, tc.dir))
+			if err != nil {
+				t.Fatalf("Build: unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantOrder, g.Order()); diff != "" {
+				t.Errorf("Order() (-want +got):\n%s", diff)
+			}
+			for addr, want := range tc.wantDeps {
+				if diff := cmp.Diff(want, g.Dependencies(addr)); diff != "" {
+					t.Errorf("Dependencies(%s) (-want +got):\n%s", addr, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildOrderIsDeterministic(t *testing.T) {
+	mod := load(t, "diamond")
+	first, err := graph.Build(mod)
+	if err != nil {
+		t.Fatalf("Build: unexpected error: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		g, err := graph.Build(mod)
+		if err != nil {
+			t.Fatalf("Build: unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(first.Order(), g.Order()); diff != "" {
+			t.Fatalf("Order() differs across runs (-first +got):\n%s", diff)
+		}
+	}
+}
+
+func TestBuildCycles(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		wantErrs []string // substrings the error must contain
+	}{
+		{
+			name:     "direct cycle via depends_on",
+			dir:      "direct_cycle",
+			wantErrs: []string{"dependency cycle: agent.a → agent.b → agent.a"},
+		},
+		{
+			name:     "transitive cycle via output references",
+			dir:      "transitive_cycle",
+			wantErrs: []string{"dependency cycle: agent.a → agent.c → agent.b → agent.a"},
+		},
+		{
+			name:     "self reference",
+			dir:      "self_reference",
+			wantErrs: []string{"dependency cycle: agent.a → agent.a"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := graph.Build(load(t, tc.dir))
+			if err == nil {
+				t.Fatalf("Build: expected error containing %q, got nil", tc.wantErrs)
+			}
+			if g != nil {
+				t.Error("Build: graph should be nil when a cycle is found")
+			}
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Build error = %q\nwant substring %q", err, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/graph/testdata/depends_on_only/adl.hcl
+++ b/internal/graph/testdata/depends_on_only/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/graph/testdata/depends_on_only/pair.agent
+++ b/internal/graph/testdata/depends_on_only/pair.agent
@@ -1,0 +1,19 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "x" {
+    type = string
+  }
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "y" {
+    type = string
+  }
+
+  depends_on = [agent.a]
+}

--- a/internal/graph/testdata/depends_on_only/sys.prompt
+++ b/internal/graph/testdata/depends_on_only/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/graph/testdata/diamond/adl.hcl
+++ b/internal/graph/testdata/diamond/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/graph/testdata/diamond/diamond.agent
+++ b/internal/graph/testdata/diamond/diamond.agent
@@ -1,0 +1,55 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "x" {
+    type = string
+  }
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_a" {
+    type    = string
+    default = agent.a.output.x
+  }
+
+  output "y" {
+    type = string
+  }
+}
+
+agent "c" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_a" {
+    type    = string
+    default = agent.a.output.x
+  }
+
+  output "z" {
+    type = string
+  }
+}
+
+agent "d" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_b" {
+    type    = string
+    default = agent.b.output.y
+  }
+
+  input "from_c" {
+    type    = string
+    default = agent.c.output.z
+  }
+
+  output "w" {
+    type = string
+  }
+}

--- a/internal/graph/testdata/diamond/sys.prompt
+++ b/internal/graph/testdata/diamond/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/graph/testdata/direct_cycle/adl.hcl
+++ b/internal/graph/testdata/direct_cycle/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/graph/testdata/direct_cycle/pair.agent
+++ b/internal/graph/testdata/direct_cycle/pair.agent
@@ -1,0 +1,21 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "x" {
+    type = string
+  }
+
+  depends_on = [agent.b]
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "y" {
+    type = string
+  }
+
+  depends_on = [agent.a]
+}

--- a/internal/graph/testdata/direct_cycle/sys.prompt
+++ b/internal/graph/testdata/direct_cycle/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/graph/testdata/linear_chain/adl.hcl
+++ b/internal/graph/testdata/linear_chain/adl.hcl
@@ -1,0 +1,9 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "dev" {
+  type   = "codegen"
+  output = "./gen/dev"
+}

--- a/internal/graph/testdata/linear_chain/chain.agent
+++ b/internal/graph/testdata/linear_chain/chain.agent
@@ -1,0 +1,38 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  tools = [tool.t]
+
+  output "x" {
+    type = string
+  }
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_a" {
+    type    = string
+    default = agent.a.output.x
+  }
+
+  output "y" {
+    type = string
+  }
+}
+
+agent "c" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_b" {
+    type    = string
+    default = agent.b.output.y
+  }
+
+  output "z" {
+    type = string
+  }
+}

--- a/internal/graph/testdata/linear_chain/sys.prompt
+++ b/internal/graph/testdata/linear_chain/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/graph/testdata/linear_chain/tools.tool
+++ b/internal/graph/testdata/linear_chain/tools.tool
@@ -1,0 +1,15 @@
+tool "t" {
+  description = "A tool"
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/graph/testdata/self_reference/adl.hcl
+++ b/internal/graph/testdata/self_reference/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/graph/testdata/self_reference/solo.agent
+++ b/internal/graph/testdata/self_reference/solo.agent
@@ -1,0 +1,13 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_self" {
+    type    = string
+    default = agent.a.output.x
+  }
+
+  output "x" {
+    type = string
+  }
+}

--- a/internal/graph/testdata/self_reference/sys.prompt
+++ b/internal/graph/testdata/self_reference/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/graph/testdata/transitive_cycle/adl.hcl
+++ b/internal/graph/testdata/transitive_cycle/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/graph/testdata/transitive_cycle/ring.agent
+++ b/internal/graph/testdata/transitive_cycle/ring.agent
@@ -1,0 +1,41 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_c" {
+    type    = string
+    default = agent.c.output.z
+  }
+
+  output "x" {
+    type = string
+  }
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_a" {
+    type    = string
+    default = agent.a.output.x
+  }
+
+  output "y" {
+    type = string
+  }
+}
+
+agent "c" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  input "from_b" {
+    type    = string
+    default = agent.b.output.y
+  }
+
+  output "z" {
+    type = string
+  }
+}

--- a/internal/graph/testdata/transitive_cycle/sys.prompt
+++ b/internal/graph/testdata/transitive_cycle/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.


### PR DESCRIPTION
Build a dependency graph over every module block from resolved references and depends_on entries. Deep references collapse to their owning block. Cycles are compile errors printing the full cycle path; acyclic modules expose a deterministic topological order for build/apply.