### PR TITLE
CLI: adl validate — full pipeline, aggregated diagnostics (#9)

### DIFF
--- a/cmd/adl/root.go
+++ b/cmd/adl/root.go
@@ -22,6 +22,7 @@ func newRootCmd() *cobra.Command {
 	}
 
 	root.AddCommand(newVersionCmd())
+	root.AddCommand(newValidateCmd())
 	return root
 }
 

--- a/cmd/adl/testdata/cycle/adl.hcl
+++ b/cmd/adl/testdata/cycle/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/cmd/adl/testdata/cycle/pair.agent
+++ b/cmd/adl/testdata/cycle/pair.agent
@@ -1,0 +1,21 @@
+agent "a" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "x" {
+    type = string
+  }
+
+  depends_on = [agent.b]
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "y" {
+    type = string
+  }
+
+  depends_on = [agent.a]
+}

--- a/cmd/adl/testdata/cycle/sys.prompt
+++ b/cmd/adl/testdata/cycle/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/cmd/adl/testdata/multi_error/broken.agent
+++ b/cmd/adl/testdata/multi_error/broken.agent
@@ -1,0 +1,4 @@
+agent "broken" {
+  model = model.m
+  this line is not valid HCL {{{
+}

--- a/cmd/adl/testdata/multi_error/solo.agent
+++ b/cmd/adl/testdata/multi_error/solo.agent
@@ -1,0 +1,8 @@
+agent "solo" {
+  model         = model.missing
+  system_prompt = prompt.sys
+
+  output "answer" {
+    type = string
+  }
+}

--- a/cmd/adl/testdata/multi_error/sys.prompt
+++ b/cmd/adl/testdata/multi_error/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/cmd/adl/testdata/unknown_ref/adl.hcl
+++ b/cmd/adl/testdata/unknown_ref/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/cmd/adl/testdata/unknown_ref/solo.agent
+++ b/cmd/adl/testdata/unknown_ref/solo.agent
@@ -1,0 +1,8 @@
+agent "solo" {
+  model         = model.fastt
+  system_prompt = prompt.sys
+
+  output "answer" {
+    type = string
+  }
+}

--- a/cmd/adl/testdata/unknown_ref/sys.prompt
+++ b/cmd/adl/testdata/unknown_ref/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/cmd/adl/testdata/valid/adl.hcl
+++ b/cmd/adl/testdata/valid/adl.hcl
@@ -1,0 +1,9 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+}

--- a/cmd/adl/testdata/valid/sys.prompt
+++ b/cmd/adl/testdata/valid/sys.prompt
@@ -1,0 +1,5 @@
+---
+name = "sys"
+requires = ["place"]
+---
+Report the weather for {{place}}.

--- a/cmd/adl/testdata/valid/tools.tool
+++ b/cmd/adl/testdata/valid/tools.tool
@@ -1,0 +1,15 @@
+tool "web_search" {
+  description = "Search the web"
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/cmd/adl/testdata/valid/weather.agent
+++ b/cmd/adl/testdata/valid/weather.agent
@@ -1,0 +1,14 @@
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.sys
+
+  tools = [tool.web_search]
+
+  input "place" {
+    type = string
+  }
+
+  output "report" {
+    type = string
+  }
+}

--- a/cmd/adl/validate.go
+++ b/cmd/adl/validate.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/weirdGuy/agentform/internal/graph"
+	"github.com/weirdGuy/agentform/internal/module"
+)
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate [dir]",
+		Short: "Parse, type-check, and resolve references in a module",
+		Long:  "validate runs the full compile pipeline without producing output: parse every ADL file under the module directory, resolve cross-file references, check prompt variable satisfiability, and build the dependency graph.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runValidate(cmd.OutOrStdout(), cmd.ErrOrStderr(), dir)
+		},
+	}
+}
+
+// runValidate runs the pipeline stages in order: module.Load (parse, symbol
+// table, reference resolution, prompt variable checks — all diagnostics
+// aggregated) then graph.Build (cycle detection). A failed stage stops the
+// run because the next stage needs its output; diagnostics within a stage
+// are always reported in full.
+func runValidate(stdout, stderr io.Writer, dir string) error {
+	mod, err := module.Load(dir)
+	if err == nil {
+		_, err = graph.Build(mod)
+	}
+	if err != nil {
+		lines := flattenDiagnostics(err, dir)
+		for _, line := range lines {
+			fmt.Fprintln(stderr, line)
+		}
+		return fmt.Errorf("validation failed: %s", countNoun(len(lines), "error"))
+	}
+
+	fmt.Fprintf(stdout, "Success! Module is valid: %s.\n", moduleSummary(mod))
+	return nil
+}
+
+// flattenDiagnostics expands an aggregated pipeline error (errors.Join trees
+// with hcl.Diagnostics leaves) into one line per diagnostic. HCL diagnostics
+// render as file:line,col with the path made relative to the module root so
+// they match the resolver's plain errors.
+func flattenDiagnostics(err error, root string) []string {
+	var lines []string
+	var walk func(error)
+	walk = func(e error) {
+		if diags, ok := e.(hcl.Diagnostics); ok {
+			for _, d := range diags {
+				lines = append(lines, formatHCLDiagnostic(d, root))
+			}
+			return
+		}
+		if multi, ok := e.(interface{ Unwrap() []error }); ok {
+			for _, sub := range multi.Unwrap() {
+				walk(sub)
+			}
+			return
+		}
+		lines = append(lines, e.Error())
+	}
+	walk(err)
+	return lines
+}
+
+func formatHCLDiagnostic(d *hcl.Diagnostic, root string) string {
+	msg := d.Summary
+	if d.Detail != "" {
+		msg += "; " + d.Detail
+	}
+	if d.Subject == nil {
+		return msg
+	}
+	file := d.Subject.Filename
+	if rel, err := filepath.Rel(root, file); err == nil && !strings.HasPrefix(rel, "..") {
+		file = rel
+	}
+	return fmt.Sprintf("%s:%d,%d: %s", file, d.Subject.Start.Line, d.Subject.Start.Column, msg)
+}
+
+func moduleSummary(mod *module.Module) string {
+	return strings.Join([]string{
+		countNoun(len(mod.Agents), "agent"),
+		countNoun(len(mod.Tools), "tool"),
+		countNoun(len(mod.Prompts), "prompt"),
+		countNoun(len(mod.Models), "model"),
+		countNoun(len(mod.Targets), "target"),
+	}, ", ")
+}
+
+func countNoun(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}

--- a/cmd/adl/validate_test.go
+++ b/cmd/adl/validate_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// runValidateCmd executes "adl validate <dir>" and returns combined output
+// and the execution error.
+func runValidateCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append([]string{"validate"}, args...))
+	err := cmd.Execute()
+	// main.go prints the returned error to stderr; append it so tests see
+	// the same combined output a user does.
+	if err != nil {
+		fmt.Fprintf(&out, "adl: %v\n", err)
+	}
+	return out.String(), err
+}
+
+func TestValidateCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		wantErr bool
+		wantOut []string // substrings that must appear in the output
+		skipOut []string // substrings that must not appear
+	}{
+		{
+			name: "valid module succeeds with summary",
+			dir:  "testdata/valid",
+			wantOut: []string{
+				"Success",
+				"1 agent",
+				"1 tool",
+				"1 prompt",
+				"1 model",
+				"1 target",
+			},
+		},
+		{
+			name:    "unknown reference fails with block address",
+			dir:     "testdata/unknown_ref",
+			wantErr: true,
+			wantOut: []string{
+				"solo.agent",
+				"agent.solo: unknown reference model.fastt",
+			},
+			skipOut: []string{"Success"},
+		},
+		{
+			name:    "dependency cycle fails naming the cycle",
+			dir:     "testdata/cycle",
+			wantErr: true,
+			wantOut: []string{
+				"dependency cycle",
+				"agent.a",
+				"agent.b",
+			},
+		},
+		{
+			name:    "all diagnostics aggregated across files",
+			dir:     "testdata/multi_error",
+			wantErr: true,
+			wantOut: []string{
+				"broken.agent:3,", // parse error with file:line position
+				"agent.solo: unknown reference model.missing",
+				"2 error",
+			},
+		},
+		{
+			name:    "missing directory fails",
+			dir:     "testdata/does_not_exist",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runValidateCmd(t, tt.dir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Execute() error = %v, wantErr %v\noutput:\n%s", err, tt.wantErr, out)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, skip := range tt.skipOut {
+				if strings.Contains(out, skip) {
+					t.Errorf("output must not contain %q:\n%s", skip, out)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCommandDefaultsToCwd(t *testing.T) {
+	// No positional arg must be accepted (defaults to "."); an empty
+	// directory is an empty module and still validates cleanly.
+	t.Chdir(t.TempDir())
+	out, err := runValidateCmd(t)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "Success") {
+		t.Errorf("output missing %q:\n%s", "Success", out)
+	}
+}


### PR DESCRIPTION
Wire module load (parse + reference resolution + prompt-var checks) and graph build (cycle detection) into an `adl validate [dir]` command. All diagnostics within a stage are reported at once, HCL diagnostics print as file:line,col relative to the module root, summary + counts on success, non-zero exit on any error.