### PR TITLE
CLI: adl fmt — canonical formatting via hclwrite (#10)

### DIFF
--- a/cmd/adl/fmt.go
+++ b/cmd/adl/fmt.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/spf13/cobra"
+
+	"github.com/weirdGuy/agentform/internal/diff"
+	"github.com/weirdGuy/agentform/internal/module"
+)
+
+func newFmtCmd() *cobra.Command {
+	var check, showDiff bool
+	cmd := &cobra.Command{
+		Use:   "fmt [dir]",
+		Short: "Canonically format ADL files",
+		Long:  "fmt rewrites the module's HCL files (.agent, .tool, adl.hcl, .adl) to canonical style and prints the names of changed files. Prompt files are left untouched — their body is preserved byte for byte. With --check nothing is written and a non-zero exit reports files that would change; --diff prints unified diffs.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runFmt(cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, check, showDiff)
+		},
+	}
+	cmd.Flags().BoolVar(&check, "check", false, "write nothing; exit non-zero if any file would change")
+	cmd.Flags().BoolVar(&showDiff, "diff", false, "print unified diffs of formatting changes")
+	return cmd
+}
+
+// runFmt formats every formattable file in the module rooted at dir. Files
+// that fail to tokenize as HCL are reported and skipped — formatting broken
+// input could mangle it further. All files are always processed; failures
+// and pending changes only decide the exit status at the end.
+func runFmt(stdout, stderr io.Writer, dir string, check, showDiff bool) error {
+	files, err := module.Files(dir)
+	if err != nil {
+		return err
+	}
+
+	var changed, failed int
+	for _, rel := range files {
+		if !formattable(rel) {
+			continue
+		}
+		path := filepath.Join(dir, rel)
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			failed++
+			continue
+		}
+		if _, diags := hclsyntax.ParseConfig(src, path, hcl.InitialPos); diags.HasErrors() {
+			for _, d := range diags {
+				fmt.Fprintln(stderr, formatHCLDiagnostic(d, dir))
+			}
+			failed++
+			continue
+		}
+
+		formatted := hclwrite.Format(src)
+		if bytes.Equal(src, formatted) {
+			continue
+		}
+		changed++
+
+		fmt.Fprintln(stdout, path)
+		if showDiff {
+			fmt.Fprint(stdout, diff.Unified(rel, src, formatted))
+		}
+		if check {
+			continue
+		}
+		// The permission argument only applies on create; an existing
+		// file keeps its mode.
+		if err := os.WriteFile(path, formatted, 0o644); err != nil {
+			fmt.Fprintln(stderr, err)
+			failed++
+		}
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("fmt failed: %s", countNoun(failed, "error"))
+	}
+	if check && changed > 0 {
+		return fmt.Errorf("%s would be reformatted", countNoun(changed, "file"))
+	}
+	return nil
+}
+
+// formattable reports whether fmt owns the file's formatting. Prompt files
+// are excluded: their body must stay byte-identical and the frontmatter is
+// not a standalone HCL document.
+func formattable(path string) bool {
+	switch filepath.Ext(path) {
+	case ".agent", ".tool", ".adl":
+		return true
+	}
+	return filepath.Base(path) == "adl.hcl"
+}

--- a/cmd/adl/fmt_test.go
+++ b/cmd/adl/fmt_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// runFmtCmd executes "adl fmt <args>" and returns combined output and the
+// execution error, mirroring runValidateCmd.
+func runFmtCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append([]string{"fmt"}, args...))
+	err := cmd.Execute()
+	if err != nil {
+		fmt.Fprintf(&out, "adl: %v\n", err)
+	}
+	return out.String(), err
+}
+
+// copyTree copies the fixture tree at src into dst.
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+	if err != nil {
+		t.Fatalf("copyTree(%s): %v", src, err)
+	}
+}
+
+// treeFiles collects a tree as a map of slash-separated relative path →
+// file content, for whole-tree comparison.
+func treeFiles(t *testing.T, root string) map[string]string {
+	t.Helper()
+	files := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("treeFiles(%s): %v", root, err)
+	}
+	return files
+}
+
+func TestFmtCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string // fixture tree under testdata/fmt copied into a temp dir
+		want    string // fixture tree the temp dir must match after the run
+		flags   []string
+		wantErr bool
+		wantOut []string // substrings that must appear in the output
+		skipOut []string // substrings that must not appear
+	}{
+		{
+			name:    "rewrites files in place and prints their names",
+			src:     "messy/before",
+			want:    "messy/after",
+			wantOut: []string{"adl.hcl", "solo.agent", "tools.tool"},
+			skipOut: []string{"clean.tool", "solo_system.prompt", "leftover"},
+		},
+		{
+			name:    "check reports files without writing",
+			src:     "messy/before",
+			want:    "messy/before",
+			flags:   []string{"--check"},
+			wantErr: true,
+			wantOut: []string{"solo.agent", "3 files would be reformatted"},
+		},
+		{
+			name:    "check passes on a formatted tree",
+			src:     "messy/after",
+			want:    "messy/after",
+			flags:   []string{"--check"},
+			skipOut: []string{"solo.agent", "adl.hcl", "tools.tool"},
+		},
+		{
+			name:  "diff prints unified diffs and still writes",
+			src:   "messy/before",
+			want:  "messy/after",
+			flags: []string{"--diff"},
+			wantOut: []string{
+				"--- a/solo.agent",
+				"+++ b/solo.agent",
+				"+  model         = model.fast",
+				"-model=model.fast",
+			},
+		},
+		{
+			name:    "check with diff prints diffs without writing",
+			src:     "messy/before",
+			want:    "messy/before",
+			flags:   []string{"--check", "--diff"},
+			wantErr: true,
+			wantOut: []string{"--- a/adl.hcl", "+++ b/adl.hcl"},
+		},
+		{
+			name:    "syntax errors are reported and other files still format",
+			src:     "syntax_error/before",
+			want:    "syntax_error/after",
+			wantErr: true,
+			wantOut: []string{"bad.agent:", "ok.agent", "1 error"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			copyTree(t, filepath.Join("testdata", "fmt", tt.src), tmp)
+
+			out, err := runFmtCmd(t, append(tt.flags, tmp)...)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Execute() error = %v, wantErr %v\noutput:\n%s", err, tt.wantErr, out)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, skip := range tt.skipOut {
+				if strings.Contains(out, skip) {
+					t.Errorf("output must not contain %q:\n%s", skip, out)
+				}
+			}
+
+			want := treeFiles(t, filepath.Join("testdata", "fmt", tt.want))
+			got := treeFiles(t, tmp)
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("tree after fmt (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestFmtIdempotent asserts fmt(fmt(x)) == fmt(x): a second run reports no
+// changes and leaves every file untouched.
+func TestFmtIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	copyTree(t, filepath.Join("testdata", "fmt", "messy", "before"), tmp)
+
+	if out, err := runFmtCmd(t, tmp); err != nil {
+		t.Fatalf("first fmt: %v\noutput:\n%s", err, out)
+	}
+	first := treeFiles(t, tmp)
+
+	out, err := runFmtCmd(t, tmp)
+	if err != nil {
+		t.Fatalf("second fmt: %v\noutput:\n%s", err, out)
+	}
+	if out != "" {
+		t.Errorf("second fmt reported changes:\n%s", out)
+	}
+	if diff := cmp.Diff(first, treeFiles(t, tmp)); diff != "" {
+		t.Errorf("second fmt modified files (-first +second):\n%s", diff)
+	}
+}
+
+func TestFmtDefaultsToCwd(t *testing.T) {
+	tmp := t.TempDir()
+	copyTree(t, filepath.Join("testdata", "fmt", "messy", "before"), tmp)
+	t.Chdir(tmp)
+
+	out, err := runFmtCmd(t)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+	got, err := os.ReadFile("solo.agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "  model         = model.fast\n"; !strings.Contains(string(got), want) {
+		t.Errorf("solo.agent not formatted, missing %q:\n%s", want, got)
+	}
+}

--- a/cmd/adl/root.go
+++ b/cmd/adl/root.go
@@ -23,6 +23,7 @@ func newRootCmd() *cobra.Command {
 
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newValidateCmd())
+	root.AddCommand(newFmtCmd())
 	return root
 }
 

--- a/cmd/adl/testdata/fmt/messy/after/adl.hcl
+++ b/cmd/adl/testdata/fmt/messy/after/adl.hcl
@@ -1,0 +1,15 @@
+# project models
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+
+  params {
+    temperature = 0.2
+    max_tokens  = 4096
+  }
+}
+
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen"
+}

--- a/cmd/adl/testdata/fmt/messy/after/clean.tool
+++ b/cmd/adl/testdata/fmt/messy/after/clean.tool
@@ -1,0 +1,15 @@
+tool "clean" {
+  description = "Already formatted"
+
+  param "q" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/cmd/adl/testdata/fmt/messy/after/gen/leftover.agent
+++ b/cmd/adl/testdata/fmt/messy/after/gen/leftover.agent
@@ -1,0 +1,3 @@
+agent "leftover"{
+model=model.fast
+}

--- a/cmd/adl/testdata/fmt/messy/after/solo.agent
+++ b/cmd/adl/testdata/fmt/messy/after/solo.agent
@@ -1,0 +1,13 @@
+agent "solo" {
+  model         = model.fast
+  system_prompt = prompt.solo_system
+  tools         = [tool.web_search]
+
+  input "question" {
+    type = string
+  }
+
+  output "answer" {
+    type = string
+  }
+}

--- a/cmd/adl/testdata/fmt/messy/after/solo_system.prompt
+++ b/cmd/adl/testdata/fmt/messy/after/solo_system.prompt
@@ -1,0 +1,5 @@
+---
+name     = "solo_system"
+requires=["question"]
+---
+You are   a solo assistant answering {{question}}.

--- a/cmd/adl/testdata/fmt/messy/after/tools.tool
+++ b/cmd/adl/testdata/fmt/messy/after/tools.tool
@@ -1,0 +1,14 @@
+tool "web_search" {
+  description = "Search the web"
+
+  param "query" {
+    type = string
+  }
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/cmd/adl/testdata/fmt/messy/before/adl.hcl
+++ b/cmd/adl/testdata/fmt/messy/before/adl.hcl
@@ -1,0 +1,15 @@
+# project models
+model "fast" {
+provider="openai"
+id = "gpt-4o-mini"
+
+params {
+temperature=0.2
+max_tokens = 4096
+}
+}
+
+target "langgraph" {
+type="codegen"
+output="./gen"
+}

--- a/cmd/adl/testdata/fmt/messy/before/clean.tool
+++ b/cmd/adl/testdata/fmt/messy/before/clean.tool
@@ -1,0 +1,15 @@
+tool "clean" {
+  description = "Already formatted"
+
+  param "q" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/cmd/adl/testdata/fmt/messy/before/gen/leftover.agent
+++ b/cmd/adl/testdata/fmt/messy/before/gen/leftover.agent
@@ -1,0 +1,3 @@
+agent "leftover"{
+model=model.fast
+}

--- a/cmd/adl/testdata/fmt/messy/before/solo.agent
+++ b/cmd/adl/testdata/fmt/messy/before/solo.agent
@@ -1,0 +1,13 @@
+agent   "solo" {
+model=model.fast
+      system_prompt   = prompt.solo_system
+  tools=[tool.web_search]
+
+  input   "question" {
+type=string
+  }
+
+output "answer" {
+      type = string
+}
+}

--- a/cmd/adl/testdata/fmt/messy/before/solo_system.prompt
+++ b/cmd/adl/testdata/fmt/messy/before/solo_system.prompt
@@ -1,0 +1,5 @@
+---
+name     = "solo_system"
+requires=["question"]
+---
+You are   a solo assistant answering {{question}}.

--- a/cmd/adl/testdata/fmt/messy/before/tools.tool
+++ b/cmd/adl/testdata/fmt/messy/before/tools.tool
@@ -1,0 +1,14 @@
+tool "web_search"{
+    description="Search the web"
+
+    param "query" {
+        type = string
+    }
+  returns {
+   type = string
+  }
+
+    source {
+     kind="builtin"
+    }
+}

--- a/cmd/adl/testdata/fmt/syntax_error/after/bad.agent
+++ b/cmd/adl/testdata/fmt/syntax_error/after/bad.agent
@@ -1,0 +1,2 @@
+agent "bad" {
+  model = model.fast

--- a/cmd/adl/testdata/fmt/syntax_error/after/ok.agent
+++ b/cmd/adl/testdata/fmt/syntax_error/after/ok.agent
@@ -1,0 +1,4 @@
+agent "ok" {
+  model         = model.fast
+  system_prompt = prompt.x
+}

--- a/cmd/adl/testdata/fmt/syntax_error/before/bad.agent
+++ b/cmd/adl/testdata/fmt/syntax_error/before/bad.agent
@@ -1,0 +1,2 @@
+agent "bad" {
+  model = model.fast

--- a/cmd/adl/testdata/fmt/syntax_error/before/ok.agent
+++ b/cmd/adl/testdata/fmt/syntax_error/before/ok.agent
@@ -1,0 +1,4 @@
+agent "ok"{
+model=model.fast
+system_prompt=prompt.x
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,160 @@
+// Package diff produces unified diffs for adl fmt's -diff output. It is a
+// small line-based LCS implementation kept in-house because the approved
+// dependency set has no diff library; it targets human review of
+// config-sized files, not patch-perfect fidelity on huge inputs.
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// context is the number of unchanged lines shown around each change,
+// matching the unified-diff default.
+const context = 3
+
+// op is one line of an edit script: kept (' '), deleted ('-'), or
+// added ('+'). Lines keep their trailing newline; a missing one triggers
+// the "\ No newline at end of file" marker on output.
+type op struct {
+	kind byte
+	text string
+	// 1-based line this op consumes in a and b; 0 when the op does not
+	// consume a line on that side.
+	aLine, bLine int
+}
+
+// Unified returns a unified diff from a to b with standard "--- a/path" /
+// "+++ b/path" headers, or "" when the inputs are identical.
+func Unified(path string, a, b []byte) string {
+	if bytes.Equal(a, b) {
+		return ""
+	}
+
+	ops := editScript(splitLines(a), splitLines(b))
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "--- a/%s\n+++ b/%s\n", path, path)
+	for _, h := range hunks(ops) {
+		writeHunk(&out, h)
+	}
+	return out.String()
+}
+
+// splitLines splits src into lines, each keeping its trailing newline.
+// A final line without a newline is kept as-is.
+func splitLines(src []byte) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	lines := strings.SplitAfter(string(src), "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// editScript computes a line-based edit script from a to b via
+// longest-common-subsequence. O(len(a)*len(b)) time and space, which is
+// fine for the file sizes adl fmt handles.
+func editScript(a, b []string) []op {
+	// lcs[i][j] = LCS length of a[i:] and b[j:].
+	lcs := make([][]int, len(a)+1)
+	for i := range lcs {
+		lcs[i] = make([]int, len(b)+1)
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		for j := len(b) - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else {
+				lcs[i][j] = max(lcs[i+1][j], lcs[i][j+1])
+			}
+		}
+	}
+
+	var ops []op
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			ops = append(ops, op{kind: ' ', text: a[i], aLine: i + 1, bLine: j + 1})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			ops = append(ops, op{kind: '-', text: a[i], aLine: i + 1})
+			i++
+		default:
+			ops = append(ops, op{kind: '+', text: b[j], bLine: j + 1})
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		ops = append(ops, op{kind: '-', text: a[i], aLine: i + 1})
+	}
+	for ; j < len(b); j++ {
+		ops = append(ops, op{kind: '+', text: b[j], bLine: j + 1})
+	}
+	return ops
+}
+
+// hunks groups the edit script into hunks with `context` unchanged lines
+// around each change, splitting where the gap between changes exceeds
+// what two contexts can bridge.
+func hunks(ops []op) [][]op {
+	var groups [][]op
+	start := -1 // index of first op in the current hunk, -1 when none open
+	end := -1   // exclusive end of the current hunk
+	for idx, o := range ops {
+		if o.kind == ' ' {
+			continue
+		}
+		if start >= 0 && idx-context > end {
+			groups = append(groups, ops[start:min(end, len(ops))])
+			start = -1
+		}
+		if start < 0 {
+			start = max(idx-context, 0)
+		}
+		end = idx + context + 1
+	}
+	if start >= 0 {
+		groups = append(groups, ops[start:min(end, len(ops))])
+	}
+	return groups
+}
+
+func writeHunk(out *strings.Builder, h []op) {
+	var aStart, aCount, bStart, bCount int
+	for _, o := range h {
+		if o.aLine > 0 {
+			if aStart == 0 {
+				aStart = o.aLine
+			}
+			aCount++
+		}
+		if o.bLine > 0 {
+			if bStart == 0 {
+				bStart = o.bLine
+			}
+			bCount++
+		}
+	}
+	// A side with no lines anchors just before the other side's position.
+	if aCount == 0 {
+		aStart = bStart - 1
+	}
+	if bCount == 0 {
+		bStart = aStart - 1
+	}
+
+	fmt.Fprintf(out, "@@ -%d,%d +%d,%d @@\n", aStart, aCount, bStart, bCount)
+	for _, o := range h {
+		out.WriteByte(o.kind)
+		out.WriteString(o.text)
+		if !strings.HasSuffix(o.text, "\n") {
+			out.WriteString("\n\\ No newline at end of file\n")
+		}
+	}
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,113 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/diff"
+)
+
+func TestUnified(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		{
+			name: "identical inputs produce no diff",
+			a:    "one\ntwo\n",
+			b:    "one\ntwo\n",
+			want: "",
+		},
+		{
+			name: "single change with surrounding context",
+			a:    "one\ntwo\nthree\nfour\nfive\nsix\nseven\n",
+			b:    "one\ntwo\nthree\nFOUR\nfive\nsix\nseven\n",
+			want: "--- a/x.agent\n" +
+				"+++ b/x.agent\n" +
+				"@@ -1,7 +1,7 @@\n" +
+				" one\n" +
+				" two\n" +
+				" three\n" +
+				"-four\n" +
+				"+FOUR\n" +
+				" five\n" +
+				" six\n" +
+				" seven\n",
+		},
+		{
+			name: "addition at end of file",
+			a:    "one\ntwo\n",
+			b:    "one\ntwo\nthree\n",
+			want: "--- a/x.agent\n" +
+				"+++ b/x.agent\n" +
+				"@@ -1,2 +1,3 @@\n" +
+				" one\n" +
+				" two\n" +
+				"+three\n",
+		},
+		{
+			name: "deletion to empty file",
+			a:    "only\n",
+			b:    "",
+			want: "--- a/x.agent\n" +
+				"+++ b/x.agent\n" +
+				"@@ -1,1 +0,0 @@\n" +
+				"-only\n",
+		},
+		{
+			name: "empty file to content",
+			a:    "",
+			b:    "one\ntwo\n",
+			want: "--- a/x.agent\n" +
+				"+++ b/x.agent\n" +
+				"@@ -0,0 +1,2 @@\n" +
+				"+one\n" +
+				"+two\n",
+		},
+		{
+			name: "distant changes split into separate hunks",
+			a:    "l01\nl02\nl03\nl04\nl05\nl06\nl07\nl08\nl09\nl10\nl11\nl12\nl13\nl14\nl15\nl16\nl17\nl18\nl19\nl20\n",
+			b:    "l01\nX02\nl03\nl04\nl05\nl06\nl07\nl08\nl09\nl10\nl11\nl12\nl13\nl14\nl15\nl16\nl17\nX18\nl19\nl20\n",
+			want: "--- a/x.agent\n" +
+				"+++ b/x.agent\n" +
+				"@@ -1,5 +1,5 @@\n" +
+				" l01\n" +
+				"-l02\n" +
+				"+X02\n" +
+				" l03\n" +
+				" l04\n" +
+				" l05\n" +
+				"@@ -15,6 +15,6 @@\n" +
+				" l15\n" +
+				" l16\n" +
+				" l17\n" +
+				"-l18\n" +
+				"+X18\n" +
+				" l19\n" +
+				" l20\n",
+		},
+		{
+			name: "missing trailing newline is marked",
+			a:    "one\ntwo",
+			b:    "one\ntwo\n",
+			want: "--- a/x.agent\n" +
+				"+++ b/x.agent\n" +
+				"@@ -1,2 +1,2 @@\n" +
+				" one\n" +
+				"-two\n" +
+				"\\ No newline at end of file\n" +
+				"+two\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diff.Unified("x.agent", []byte(tt.a), []byte(tt.b))
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Errorf("Unified (-want +got):\n%s", d)
+			}
+		})
+	}
+}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -46,30 +46,62 @@ func (m *Module) Lookup(addr string) (*Symbol, bool) {
 	return sym, ok
 }
 
-// Load walks the directory tree rooted at root, parses every ADL file
-// (.agent, .tool, .prompt, .adl, adl.hcl), and resolves all references.
-// Hidden files and directories (dot-prefixed) are skipped. All errors —
-// parse failures, cross-file duplicate addresses, unknown references — are
-// collected and returned joined, so one run reports everything.
+// Load parses every ADL file in the module rooted at root (.agent, .tool,
+// .prompt, .adl, adl.hcl — discovered via Files) and resolves all
+// references. All errors — parse failures, cross-file duplicate addresses,
+// unknown references — are collected and returned joined, so one run
+// reports everything.
 func Load(root string) (*Module, error) {
-	info, err := os.Stat(root)
+	files, err := Files(root)
 	if err != nil {
 		return nil, fmt.Errorf("loading module: %w", err)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("loading module: %s is not a directory", root)
 	}
 
 	mod := &Module{Root: root, symbols: map[string]*Symbol{}}
 
 	var errs []error
+	for _, rel := range files {
+		errs = append(errs, mod.loadFile(filepath.Join(root, rel), rel)...)
+	}
+
+	for _, a := range mod.Agents {
+		errs = append(errs, mod.resolveAgent(a)...)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	return mod, nil
+}
+
+// Files walks the directory tree rooted at root and returns the relative
+// paths of every file that belongs to the module, in lexical walk order.
+// Hidden (dot-prefixed) files and directories are skipped, as are the
+// output directories of codegen targets declared in the module's project
+// files — generated code is never module input. Non-ADL files are
+// included; callers filter by extension.
+func Files(root string) ([]string, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	skip, err := outputDirs(root)
+	if err != nil {
+		return nil, fmt.Errorf("walking module directory: %w", err)
+	}
+
+	var files []string
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		hidden := strings.HasPrefix(d.Name(), ".") && path != root
 		if d.IsDir() {
-			if hidden {
+			if hidden || skip[filepath.Clean(path)] {
 				return filepath.SkipDir
 			}
 			return nil
@@ -82,21 +114,61 @@ func Load(root string) (*Module, error) {
 		if err != nil {
 			return err
 		}
-		errs = append(errs, mod.loadFile(path, rel)...)
+		files = append(files, rel)
 		return nil
 	})
 	if walkErr != nil {
 		return nil, fmt.Errorf("walking module directory: %w", walkErr)
 	}
+	return files, nil
+}
 
-	for _, a := range mod.Agents {
-		errs = append(errs, mod.resolveAgent(a)...)
-	}
+// outputDirs pre-scans the tree for project files and collects their
+// codegen target output directories, resolved relative to the declaring
+// file. A project file that fails to parse contributes nothing here — the
+// parse error surfaces when the file itself is loaded or formatted.
+func outputDirs(root string) (map[string]bool, error) {
+	dirs := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		hidden := strings.HasPrefix(d.Name(), ".") && path != root
+		if d.IsDir() {
+			if hidden {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if hidden || !isProjectFile(path) {
+			return nil
+		}
 
-	if err := errors.Join(errs...); err != nil {
+		project, err := parser.ParseProjectFile(path)
+		if err != nil {
+			return nil
+		}
+		for _, t := range project.Targets {
+			if t.Output == "" {
+				continue
+			}
+			out := t.Output
+			if !filepath.IsAbs(out) {
+				out = filepath.Join(filepath.Dir(path), out)
+			}
+			dirs[filepath.Clean(out)] = true
+		}
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
-	return mod, nil
+	return dirs, nil
+}
+
+// isProjectFile reports whether path is a project file (adl.hcl or *.adl).
+func isProjectFile(path string) bool {
+	return filepath.Ext(path) == ".adl" || filepath.Base(path) == "adl.hcl"
 }
 
 // loadFile parses one ADL file (dispatched on its name) and registers its
@@ -143,7 +215,7 @@ func (m *Module) loadFile(path, rel string) []error {
 			m.Prompts = append(m.Prompts, prompt)
 		}
 	case ".adl", ".hcl":
-		if filepath.Ext(path) == ".hcl" && filepath.Base(path) != "adl.hcl" {
+		if !isProjectFile(path) {
 			return nil
 		}
 		project, err := parser.ParseProjectFile(path)

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -58,6 +58,40 @@ func TestLoadValidModule(t *testing.T) {
 	}
 }
 
+func TestFiles(t *testing.T) {
+	got, err := module.Files(filepath.Join("testdata", "walk_skip"))
+	if err != nil {
+		t.Fatalf("Files: unexpected error: %v", err)
+	}
+
+	// Lexical walk order; dot-directories and the codegen target output
+	// directory (gen/, from adl.hcl) are skipped. Non-ADL files are still
+	// listed — callers filter by extension.
+	want := []string{
+		"README.md",
+		"adl.hcl",
+		"solo.agent",
+		"solo_system.prompt",
+		filepath.Join("sub", "search.tool"),
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Files (-want +got):\n%s", diff)
+	}
+}
+
+func TestLoadSkipsTargetOutputDirs(t *testing.T) {
+	mod, err := module.Load(filepath.Join("testdata", "walk_skip"))
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	if _, ok := mod.Lookup("agent.leftover"); ok {
+		t.Error("agent.leftover found: generated output directory was not skipped")
+	}
+	if _, ok := mod.Lookup("agent.solo"); !ok {
+		t.Error("agent.solo not found")
+	}
+}
+
 func TestLoadEmptyDir(t *testing.T) {
 	mod, err := module.Load(t.TempDir())
 	if err != nil {

--- a/internal/module/testdata/walk_skip/.hidden/hidden.agent
+++ b/internal/module/testdata/walk_skip/.hidden/hidden.agent
@@ -1,0 +1,4 @@
+agent "hidden" {
+  model         = model.ghost
+  system_prompt = prompt.ghost
+}

--- a/internal/module/testdata/walk_skip/README.md
+++ b/internal/module/testdata/walk_skip/README.md
@@ -1,0 +1,5 @@
+# walk_skip
+
+Fixture for module.Files: the gen/ directory is a codegen target output and
+must be skipped, as must dot-directories. Non-ADL files like this one are
+still listed; callers filter by extension.

--- a/internal/module/testdata/walk_skip/adl.hcl
+++ b/internal/module/testdata/walk_skip/adl.hcl
@@ -1,0 +1,9 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen"
+}

--- a/internal/module/testdata/walk_skip/gen/leftover.agent
+++ b/internal/module/testdata/walk_skip/gen/leftover.agent
@@ -1,0 +1,4 @@
+agent "leftover" {
+  model         = model.ghost
+  system_prompt = prompt.ghost
+}

--- a/internal/module/testdata/walk_skip/solo.agent
+++ b/internal/module/testdata/walk_skip/solo.agent
@@ -1,0 +1,4 @@
+agent "solo" {
+  model         = model.fast
+  system_prompt = prompt.solo_system
+}

--- a/internal/module/testdata/walk_skip/solo_system.prompt
+++ b/internal/module/testdata/walk_skip/solo_system.prompt
@@ -1,0 +1,4 @@
+---
+name = "solo_system"
+---
+You are a solo assistant.

--- a/internal/module/testdata/walk_skip/sub/search.tool
+++ b/internal/module/testdata/walk_skip/sub/search.tool
@@ -1,0 +1,15 @@
+tool "search" {
+  description = "Search"
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}


### PR DESCRIPTION
- adl fmt [dir] rewrites .agent/.tool/adl.hcl/.adl in place and prints changed file names; --check writes nothing and exits non-zero; --diff prints unified diffs (still writes unless --check)
- .prompt files are skipped: body is byte-preserved per SPEC.md §3.4 and frontmatter is not a standalone HCL document
- module.Files: shared walk (dot-dirs and codegen target output dirs skipped) now backing both Load and fmt
- internal/diff: dependency-free line-based unified diff for --diff
- files that fail to tokenize are reported with position and skipped; remaining files still format, run exits non-zero