### PR TITLE
Parser: system_prompt is optional on agents (#7)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -96,6 +96,7 @@ agent "weather" {
 - Agent owns the **model** and the **IO contract**.
 - Prompt owns only its **template body** and the **variables it requires**.
 - Validation: every variable a prompt requires must be satisfiable from the agent's inputs/outputs; conflict = compile error.
+- `system_prompt` is **optional** (issue #7): an agent may omit it entirely, in which case the prompt-variable check is a no-op. When present it must be a `prompt.<name>` reference.
 ### 3.3 `tool` (.tool file)
  
 A tool is an **interface + implementation source**.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -40,7 +40,10 @@ func Build(mod *module.Module) (*Graph, error) {
 		g.deps[t.Addr()] = nil
 	}
 	for _, a := range mod.Agents {
-		refs := []string{a.Model, a.SystemPrompt}
+		refs := []string{a.Model}
+		if a.SystemPrompt != "" {
+			refs = append(refs, a.SystemPrompt)
+		}
 		refs = append(refs, a.Tools...)
 		refs = append(refs, a.DependsOn...)
 		for _, in := range a.Inputs {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -65,6 +65,18 @@ func TestBuildValid(t *testing.T) {
 				"agent.b": {"agent.a", "model.m", "prompt.sys"},
 			},
 		},
+		{
+			name: "agent without system_prompt contributes no prompt edge",
+			dir:  "no_system_prompt",
+			wantOrder: []string{
+				"model.m", "agent.a",
+				"prompt.sys", "agent.b",
+			},
+			wantDeps: map[string][]string{
+				"agent.a": {"model.m"},
+				"agent.b": {"agent.a", "model.m", "prompt.sys"},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/graph/testdata/no_system_prompt/adl.hcl
+++ b/internal/graph/testdata/no_system_prompt/adl.hcl
@@ -1,0 +1,4 @@
+model "m" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/graph/testdata/no_system_prompt/pair.agent
+++ b/internal/graph/testdata/no_system_prompt/pair.agent
@@ -1,0 +1,18 @@
+agent "a" {
+  model = model.m
+
+  output "x" {
+    type = string
+  }
+}
+
+agent "b" {
+  model         = model.m
+  system_prompt = prompt.sys
+
+  output "y" {
+    type = string
+  }
+
+  depends_on = [agent.a]
+}

--- a/internal/graph/testdata/no_system_prompt/sys.prompt
+++ b/internal/graph/testdata/no_system_prompt/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -252,7 +252,9 @@ func (m *Module) resolveAgent(a *schema.Agent) []error {
 	}
 
 	check(a.Model)
-	check(a.SystemPrompt)
+	if a.SystemPrompt != "" {
+		check(a.SystemPrompt)
+	}
 	for _, ref := range a.Tools {
 		check(ref)
 	}

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -58,6 +58,22 @@ func TestLoadValidModule(t *testing.T) {
 	}
 }
 
+// SPEC.md §3.2: system_prompt is optional; without one the prompt-variable
+// check is a no-op, and the agent must still be a valid depends_on target.
+func TestLoadAgentWithoutSystemPrompt(t *testing.T) {
+	mod, err := module.Load(filepath.Join("testdata", "no_system_prompt"))
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	sym, ok := mod.Lookup("agent.geocoder")
+	if !ok {
+		t.Fatal(`Lookup("agent.geocoder") not found`)
+	}
+	if got := sym.Block.(*schema.Agent).SystemPrompt; got != "" {
+		t.Errorf("SystemPrompt = %q, want empty", got)
+	}
+}
+
 func TestFiles(t *testing.T) {
 	got, err := module.Files(filepath.Join("testdata", "walk_skip"))
 	if err != nil {

--- a/internal/module/testdata/no_system_prompt/adl.hcl
+++ b/internal/module/testdata/no_system_prompt/adl.hcl
@@ -1,0 +1,4 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}

--- a/internal/module/testdata/no_system_prompt/pair.agent
+++ b/internal/module/testdata/no_system_prompt/pair.agent
@@ -1,0 +1,22 @@
+agent "geocoder" {
+  model = model.fast
+
+  input "location" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}
+
+agent "weather" {
+  model         = model.fast
+  system_prompt = prompt.sys
+
+  output "weather" {
+    type = string
+  }
+
+  depends_on = [agent.geocoder]
+}

--- a/internal/module/testdata/no_system_prompt/sys.prompt
+++ b/internal/module/testdata/no_system_prompt/sys.prompt
@@ -1,0 +1,4 @@
+---
+name = "sys"
+---
+You are a helpful agent.

--- a/internal/parser/agent.go
+++ b/internal/parser/agent.go
@@ -95,11 +95,15 @@ func decodeAgent(a agentHCL) (*schema.Agent, error) {
 	}
 	agent.Model = model
 
-	systemPrompt, err := requiredRef(agent.Addr(), "system_prompt", "prompt", a.SystemPrompt)
-	if err != nil {
-		return nil, err
+	// SPEC.md §3.2: system_prompt is optional; without one the prompt-variable
+	// check downstream is a no-op.
+	if !absentExpr(a.SystemPrompt) {
+		systemPrompt, err := simpleRef(agent.Addr(), "system_prompt", "prompt", a.SystemPrompt)
+		if err != nil {
+			return nil, err
+		}
+		agent.SystemPrompt = systemPrompt
 	}
-	agent.SystemPrompt = systemPrompt
 
 	tools, err := refList(agent.Addr(), "tools", "tool", a.Tools)
 	if err != nil {

--- a/internal/parser/agent_test.go
+++ b/internal/parser/agent_test.go
@@ -42,13 +42,25 @@ func TestParseAgentFile(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal agent needs only model and system_prompt",
+			name: "agent with only model and system_prompt",
 			file: "valid_minimal.agent",
 			want: []*schema.Agent{
 				{
 					Name:         "echo",
 					Model:        "model.fast",
 					SystemPrompt: "prompt.echo_system",
+				},
+			},
+		},
+		{
+			name: "system_prompt is optional; absent leaves the reference empty",
+			file: "valid_no_system_prompt.agent",
+			want: []*schema.Agent{
+				{
+					Name:    "geocoder",
+					Model:   "model.fast",
+					Inputs:  []*schema.AgentInput{{Name: "location", Type: "string"}},
+					Outputs: []*schema.AgentOutput{{Name: "coordinates", Type: "string"}},
 				},
 			},
 		},

--- a/internal/parser/testdata/valid_no_system_prompt.agent
+++ b/internal/parser/testdata/valid_no_system_prompt.agent
@@ -1,0 +1,11 @@
+agent "geocoder" {
+  model = model.fast
+
+  input "location" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}

--- a/internal/schema/agent.go
+++ b/internal/schema/agent.go
@@ -7,7 +7,7 @@ type Agent struct {
 	Name         string // block label, e.g. "weather" in agent.weather
 	Description  string // optional
 	Model        string // required reference, "model.<name>"
-	SystemPrompt string // required reference, "prompt.<name>"
+	SystemPrompt string // optional reference, "prompt.<name>"; empty when absent
 	Tools        []string
 	Inputs       []*AgentInput
 	Outputs      []*AgentOutput


### PR DESCRIPTION
system_prompt was decoded with requiredRef, rejecting agents that omit it — a regression against #7's design, where the prompt-variable check is simply a no-op when no prompt is set. This also cascaded in module loading: a failed agent never enters the symbol table, so depends_on references to it (correctly walked since #6) reported unknown reference.

Decode system_prompt as optional, skip the empty reference in module resolution and graph edges, and clarify optionality in SPEC.md §3.2. Fixtures: promptless agent in parser, module (as a depends_on target), and graph (no phantom prompt edge) suites.