### PR TITLE
adl build command wiring (#38)

### DIFF
--- a/cmd/adl/build.go
+++ b/cmd/adl/build.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/weirdGuy/agentform/internal/build"
+	"github.com/weirdGuy/agentform/internal/build/langgraph"
+	"github.com/weirdGuy/agentform/internal/graph"
+	"github.com/weirdGuy/agentform/internal/module"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+// generators maps a codegen target's name to its framework generator: the
+// target label doubles as the framework selector (SPEC.md §3.5 has no
+// separate framework attribute). A codegen target whose name has no entry
+// here is a codegen error at build time, not a validation error — the block
+// itself is valid spec.
+var generators = map[string]build.Generator{
+	"langgraph": langgraph.Generator{},
+}
+
+func newBuildCmd() *cobra.Command {
+	var target string
+	cmd := &cobra.Command{
+		Use:   "build [--target name] [dir]",
+		Short: "Generate framework code from the module's codegen targets",
+		Long:  "build runs the full validate pipeline, then generates code for the module's codegen targets and syncs it into each target's declared output directory. With --target only the named target is built; otherwise all codegen targets build in lexicographic name order. Platform targets are never built — they belong to adl plan / adl apply.",
+		Args:  usageMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runBuild(cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, target)
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "", "build only the named codegen target (default: all codegen targets)")
+	return cmd
+}
+
+// usageMaxArgs is cobra.MaximumNArgs with the usage exit code attached.
+func usageMaxArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := cobra.MaximumNArgs(n)(cmd, args); err != nil {
+			return withExitCode(2, err)
+		}
+		return nil
+	}
+}
+
+// runBuild validates the module exactly like adl validate, then builds the
+// selected codegen targets in order, stopping at the first failure. Output
+// already synced for earlier targets stays in place — every target's sync is
+// independently complete or untouched.
+func runBuild(stdout, stderr io.Writer, dir, targetName string) error {
+	mod, g, err := compileModule(stderr, dir)
+	if err != nil {
+		return err
+	}
+
+	targets, err := selectTargets(mod, targetName)
+	if err != nil {
+		return err
+	}
+
+	for _, tgt := range targets {
+		if err := buildTarget(stdout, mod, g, tgt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// selectTargets picks the codegen targets to build: the named one, or all of
+// them in lexicographic name order when no name is given. Selection failures
+// are usage errors (exit 2): the invocation asked the module for something
+// it does not declare.
+func selectTargets(mod *module.Module, name string) ([]*schema.Target, error) {
+	if name != "" {
+		for _, tgt := range mod.Targets {
+			if tgt.Name != name {
+				continue
+			}
+			if tgt.Type != "codegen" {
+				return nil, usageErrorf("target.%s is a %s target; adl build only builds codegen targets — use adl plan / adl apply for it", name, tgt.Type)
+			}
+			return []*schema.Target{tgt}, nil
+		}
+		return nil, usageErrorf("target.%s: not declared in the module (codegen targets: %s)", name, joinOrNone(codegenNames(mod)))
+	}
+
+	var targets []*schema.Target
+	for _, tgt := range mod.Targets {
+		if tgt.Type == "codegen" {
+			targets = append(targets, tgt)
+		}
+	}
+	if len(targets) == 0 {
+		return nil, usageErrorf("module declares no codegen targets; adl build needs at least one target with type = \"codegen\"")
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i].Name < targets[j].Name })
+	return targets, nil
+}
+
+// buildTarget generates one codegen target and syncs the files into its
+// output directory. Generation failures keep the default exit code 1
+// (codegen errors); sync failures are IO errors, exit 2.
+func buildTarget(stdout io.Writer, mod *module.Module, g *graph.Graph, tgt *schema.Target) error {
+	gen, ok := generators[tgt.Name]
+	if !ok {
+		return fmt.Errorf("%s: no code generator named %q (available: %s)", tgt.Addr(), tgt.Name, strings.Join(generatorNames(), ", "))
+	}
+
+	files, err := build.Run(gen, &build.Job{Module: mod, Graph: g, Target: tgt})
+	if err != nil {
+		return err
+	}
+
+	outDir, err := build.OutputDir(mod, tgt)
+	if err != nil {
+		return err
+	}
+	if err := build.Write(outDir, files); err != nil {
+		return withExitCode(2, fmt.Errorf("%s: %w", tgt.Addr(), err))
+	}
+
+	fmt.Fprintf(stdout, "Built target %s: %s → %s\n", tgt.Name, countNoun(len(files), "file"), displayPath(outDir))
+	return nil
+}
+
+func codegenNames(mod *module.Module) []string {
+	var names []string
+	for _, tgt := range mod.Targets {
+		if tgt.Type == "codegen" {
+			names = append(names, tgt.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func generatorNames() []string {
+	names := make([]string, 0, len(generators))
+	for name := range generators {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func joinOrNone(names []string) string {
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ", ")
+}
+
+// displayPath renders the resolved output directory relative to the working
+// directory when it lies beneath it, matching how users write output paths.
+func displayPath(dir string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return dir
+	}
+	rel, err := filepath.Rel(wd, dir)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return dir
+	}
+	return rel
+}

--- a/cmd/adl/build_test.go
+++ b/cmd/adl/build_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// runBuildCmd executes "adl build <args>" and returns combined output and
+// the execution error.
+func runBuildCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append([]string{"build"}, args...))
+	err := cmd.Execute()
+	// main.go prints the returned error to stderr; append it so tests see
+	// the same combined output a user does.
+	if err != nil {
+		fmt.Fprintf(&out, "adl: %v\n", err)
+	}
+	return out.String(), err
+}
+
+// copyModule copies a testdata module into a temp directory so builds never
+// write generated output into the repository.
+func copyModule(t *testing.T, src string) string {
+	t.Helper()
+	dst := t.TempDir()
+	if err := os.CopyFS(dst, os.DirFS(src)); err != nil {
+		t.Fatalf("copying %s: %v", src, err)
+	}
+	return dst
+}
+
+func TestBuildCommandErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		args     []string
+		wantCode int      // expected process exit code for the error
+		wantOut  []string // substrings that must appear in the output
+		skipOut  []string // substrings that must not appear
+	}{
+		{
+			name:     "unknown target is a usage error",
+			dir:      "testdata/valid",
+			args:     []string{"--target", "nope"},
+			wantCode: 2,
+			wantOut:  []string{`target.nope`, "langgraph"},
+			skipOut:  []string{"Built"},
+		},
+		{
+			name:     "platform target directs to plan/apply",
+			dir:      "testdata/build/platform_only",
+			args:     []string{"--target", "openai_assistants"},
+			wantCode: 2,
+			wantOut:  []string{"target.openai_assistants", "platform", "adl plan"},
+			skipOut:  []string{"Built"},
+		},
+		{
+			name:     "invalid module never generates",
+			dir:      "testdata/unknown_ref",
+			wantCode: 1,
+			wantOut:  []string{"agent.solo: unknown reference model.fastt"},
+			skipOut:  []string{"Built"},
+		},
+		{
+			name:     "zero codegen targets is an error not a no-op",
+			dir:      "testdata/build/platform_only",
+			wantCode: 2,
+			wantOut:  []string{"no codegen targets"},
+			skipOut:  []string{"Built"},
+		},
+		{
+			name:     "codegen target without a generator fails",
+			dir:      "testdata/build/no_generator",
+			wantCode: 1,
+			wantOut:  []string{"target.alpha", "no code generator", "langgraph"},
+			// Builds run in lexicographic target-name order and stop at the
+			// first failure, so target.zed is never attempted.
+			skipOut: []string{"target.zed"},
+		},
+		{
+			name:     "generator errors surface with the block address",
+			dir:      "testdata/valid", // its only tool is kind=builtin: a codegen error
+			args:     []string{"--target", "langgraph"},
+			wantCode: 1,
+			wantOut:  []string{"target.langgraph", "builtin"},
+			skipOut:  []string{"Built"},
+		},
+		{
+			name:     "missing directory fails",
+			dir:      "testdata/does_not_exist",
+			wantCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runBuildCmd(t, append([]string{tt.dir}, tt.args...)...)
+			if err == nil {
+				t.Fatalf("Execute() succeeded, want error\noutput:\n%s", out)
+			}
+			if code := exitCode(err); code != tt.wantCode {
+				t.Errorf("exit code = %d, want %d (error: %v)", code, tt.wantCode, err)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, skip := range tt.skipOut {
+				if strings.Contains(out, skip) {
+					t.Errorf("output must not contain %q:\n%s", skip, out)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildCommandSingleTarget(t *testing.T) {
+	dir := copyModule(t, "testdata/build/single")
+	out, err := runBuildCmd(t, dir, "--target", "langgraph")
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "Built target langgraph:") {
+		t.Errorf("output missing success line:\n%s", out)
+	}
+	for _, f := range []string{".adlbuild", "models.py", filepath.Join("agents", "solo.py")} {
+		if _, err := os.Stat(filepath.Join(dir, "gen", "langgraph", f)); err != nil {
+			t.Errorf("expected generated file %s: %v", f, err)
+		}
+	}
+}
+
+func TestBuildCommandDefaultsToCwd(t *testing.T) {
+	dir := copyModule(t, "testdata/build/single")
+	t.Chdir(dir)
+	out, err := runBuildCmd(t)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "Built target langgraph:") {
+		t.Errorf("output missing success line:\n%s", out)
+	}
+}
+
+// TestBuildCommandWeatherExample builds the repo's end-to-end example with no
+// --target flag: all codegen targets build, the platform target is left to
+// plan/apply, and the reported file count matches what lands on disk in the
+// declared output directory.
+func TestBuildCommandWeatherExample(t *testing.T) {
+	dir := copyModule(t, filepath.Join("..", "..", "examples", "weather"))
+	out, err := runBuildCmd(t, dir)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+
+	m := regexp.MustCompile(`Built target langgraph: (\d+) files → `).FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("output missing countable success line:\n%s", out)
+	}
+	reported, _ := strconv.Atoi(m[1])
+
+	outDir := filepath.Join(dir, "gen", "langgraph")
+	for _, f := range []string{
+		".adlbuild",
+		"models.py",
+		filepath.Join("agents", "weather.py"),
+		filepath.Join("agents", "forecast.py"),
+		filepath.Join("agents", "geocoder.py"),
+		filepath.Join("tools", "web_search.py"),
+	} {
+		if _, err := os.Stat(filepath.Join(outDir, f)); err != nil {
+			t.Errorf("expected generated file %s: %v", f, err)
+		}
+	}
+
+	// Every visible file in the output dir must be accounted for by the
+	// reported count (the marker is hidden and excluded).
+	var onDisk int
+	err = filepath.WalkDir(outDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && !strings.HasPrefix(d.Name(), ".") {
+			onDisk++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking output dir: %v", err)
+	}
+	if reported != onDisk {
+		t.Errorf("reported %d files, found %d on disk", reported, onDisk)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	if got := exitCode(errors.New("plain")); got != 1 {
+		t.Errorf("plain error exit code = %d, want 1", got)
+	}
+	wrapped := fmt.Errorf("outer: %w", usageErrorf("bad flag"))
+	if got := exitCode(wrapped); got != 2 {
+		t.Errorf("wrapped usage error exit code = %d, want 2", got)
+	}
+}

--- a/cmd/adl/exit.go
+++ b/cmd/adl/exit.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// exitError tags an error with the process exit status main should use.
+// Convention (issue #38): 0 clean, 1 validation/codegen errors (the default
+// for untagged errors), 2 usage/IO errors.
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
+// withExitCode tags err with a specific exit status, preserving the error
+// chain for errors.As/Is.
+func withExitCode(code int, err error) error {
+	return &exitError{code: code, err: err}
+}
+
+// usageErrorf builds an exit-code-2 error for a bad invocation: wrong flags
+// or arguments, or a target selection the module cannot satisfy.
+func usageErrorf(format string, args ...any) error {
+	return withExitCode(2, fmt.Errorf(format, args...))
+}
+
+// exitCode maps a command error to the process exit status.
+func exitCode(err error) int {
+	var coded *exitError
+	if errors.As(err, &coded) {
+		return coded.code
+	}
+	return 1
+}

--- a/cmd/adl/main.go
+++ b/cmd/adl/main.go
@@ -8,6 +8,6 @@ import (
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "adl: %v\n", err)
-		os.Exit(1)
+		os.Exit(exitCode(err))
 	}
 }

--- a/cmd/adl/root.go
+++ b/cmd/adl/root.go
@@ -21,8 +21,14 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 
+	// Flag misuse is a usage error (exit 2), like bad positional args.
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return withExitCode(2, err)
+	})
+
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newValidateCmd())
+	root.AddCommand(newBuildCmd())
 	root.AddCommand(newFmtCmd())
 	return root
 }

--- a/cmd/adl/testdata/build/no_generator/adl.hcl
+++ b/cmd/adl/testdata/build/no_generator/adl.hcl
@@ -1,0 +1,11 @@
+# Two codegen targets whose names match no known generator: builds run in
+# lexicographic target-name order, so target.alpha must fail first.
+target "zed" {
+  type   = "codegen"
+  output = "./gen/zed"
+}
+
+target "alpha" {
+  type   = "codegen"
+  output = "./gen/alpha"
+}

--- a/cmd/adl/testdata/build/platform_only/adl.hcl
+++ b/cmd/adl/testdata/build/platform_only/adl.hcl
@@ -1,0 +1,7 @@
+target "openai_assistants" {
+  type = "platform"
+
+  auth {
+    api_key_env = "OPENAI_API_KEY"
+  }
+}

--- a/cmd/adl/testdata/build/single/adl.hcl
+++ b/cmd/adl/testdata/build/single/adl.hcl
@@ -1,0 +1,9 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+}

--- a/cmd/adl/testdata/build/single/solo.agent
+++ b/cmd/adl/testdata/build/single/solo.agent
@@ -1,0 +1,11 @@
+agent "solo" {
+  model = model.fast
+
+  input "question" {
+    type = string
+  }
+
+  output "answer" {
+    type = string
+  }
+}

--- a/cmd/adl/validate.go
+++ b/cmd/adl/validate.go
@@ -29,26 +29,35 @@ func newValidateCmd() *cobra.Command {
 	}
 }
 
-// runValidate runs the pipeline stages in order: module.Load (parse, symbol
+func runValidate(stdout, stderr io.Writer, dir string) error {
+	mod, _, err := compileModule(stderr, dir)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "Success! Module is valid: %s.\n", moduleSummary(mod))
+	return nil
+}
+
+// compileModule runs the pipeline stages in order: module.Load (parse, symbol
 // table, reference resolution, prompt variable checks — all diagnostics
 // aggregated) then graph.Build (cycle detection). A failed stage stops the
 // run because the next stage needs its output; diagnostics within a stage
-// are always reported in full.
-func runValidate(stdout, stderr io.Writer, dir string) error {
+// are always reported in full to stderr. Both validate and build sit on this
+// — build must never generate from a module that fails it.
+func compileModule(stderr io.Writer, dir string) (*module.Module, *graph.Graph, error) {
 	mod, err := module.Load(dir)
+	var g *graph.Graph
 	if err == nil {
-		_, err = graph.Build(mod)
+		g, err = graph.Build(mod)
 	}
 	if err != nil {
 		lines := flattenDiagnostics(err, dir)
 		for _, line := range lines {
 			fmt.Fprintln(stderr, line)
 		}
-		return fmt.Errorf("validation failed: %s", countNoun(len(lines), "error"))
+		return nil, nil, fmt.Errorf("validation failed: %s", countNoun(len(lines), "error"))
 	}
-
-	fmt.Fprintf(stdout, "Success! Module is valid: %s.\n", moduleSummary(mod))
-	return nil
+	return mod, g, nil
 }
 
 // flattenDiagnostics expands an aggregated pipeline error (errors.Join trees


### PR DESCRIPTION
Closes #38. Wires the codegen engine (#11) and LangGraph generator (#12) into a cobra command — the M2 counterpart of #9.

## What

`adl build [--target NAME] [dir]`:

- Runs the exact validate pipeline first (`compileModule`, extracted from `adl validate` — same diagnostics, same output); never generates from an invalid module.
- `--target NAME` builds one target: must exist and be `type = "codegen"`; a platform target errors with a pointer to `adl plan` / `adl apply`.
- No flag: builds **all** codegen targets in lexicographic name order, stopping at the first failure (each target's sync is independently complete or untouched). Zero codegen targets is an error, not a silent no-op.
- Files sync through `build.Write` to the target's declared `output` (resync semantics unchanged: tracked files regenerated, dot-entries left alone).
- Countable success line: `Built target langgraph: 14 files → examples/weather/gen/langgraph`.

## Exit codes

New `exitError` plumbing in `cmd/adl` (main.go honors it): 0 clean, **1** validation/codegen errors (default for untagged errors), **2** usage/IO errors. Flag misuse also exits 2 via a root `FlagErrorFunc`.

## Design decisions not covered by SPEC.md (flagging, not silently deciding)

1. **Target label = generator selector.** §3.5 has no `framework` attribute, so the codegen target's name picks the generator (`langgraph`). A codegen target whose name matches no generator is a *build-time codegen error* (exit 1), not a validation error — the block itself is valid spec. If we'd rather validate reject it, that's a schema change worth its own issue.
2. **Build-all on omitted `--target`** (per issue text), lexicographic order, stop at first failure. Single-target-required was the alternative; build-all matches Terraform's "the module is the unit" feel.
3. **Exit-code classification:** unknown target, platform target selected, and zero codegen targets are all *usage* errors (exit 2) — the invocation asked the module for something it doesn't declare; the spec itself is fine. `build.Write` failures (including the unclaimed-directory refusal) are IO → 2. Generator errors (e.g. `builtin` tool on langgraph) → 1.
4. **Flag/arg spelling:** cobra/pflag gives GNU-style `--target`; the issue's `-target` (Go-flag style) parses as a shorthand cluster and exits 2. Module dir stays optional defaulting to `.`, consistent with `validate` and `fmt`.
5. **SPEC.md §5 untouched** — the table row `adl build [-target X]` still matches modulo dash style; happy to update it to `--target` in a docs commit if wanted.

Not in scope: committing `examples/weather/gen/` output (that's #19's call).

## Tests

Table-driven negatives: unknown target, platform target, invalid module (never generates), zero codegen targets, no-generator target (also proves lexicographic order — `target.alpha` fails before `target.zed` is attempted), generator error surfacing the block address, missing dir. Success paths run against temp copies (never write into testdata), including an integration test on `examples/weather/` that asserts the reported file count matches what lands on disk.

Verified end-to-end with the built binary: build/rebuild of examples/weather (idempotent, 14 files), all error paths exercised with their exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)