### PR TITLE
Provider interface + state file: target-agnostic plan/apply engine (#15, #14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@
 # artifacts are not needed to detect drift.
 examples/**/gen/
 
+# Plan/apply state: maps block addresses to remote resource ids —
+# environment-specific like tfstate, never committed. The lock file is
+# transient by design. (State-package test fixtures live in tracked
+# testdata directories and are unaffected by these example-scoped rules.)
+examples/**/adl.state.json
+examples/**/.adl.state.lock
+
 # MCP server connection config: can carry API keys in URLs (hosted
 # endpoints like Tavily embed the key as a query param). Must never be
 # committable by accident.

--- a/SPEC.md
+++ b/SPEC.md
@@ -245,7 +245,59 @@ target "openai_assistants" {
 | `adl destroy` | Remove managed remote agents |
 | `adl fmt` | Canonical formatting |
  
-State file (`adl.state.json`): maps block addresses → remote resource IDs, tracks last-applied config for drift detection.
+Exit codes (all commands): 0 clean, 1 validation/codegen/plan/apply errors, 2 usage/IO errors (including lock contention).
+
+### 5.1 State file
+
+`adl.state.json`, at the module root, records what `adl apply` manages: block addresses → remote resource IDs, plus the configuration last applied to each.
+
+```json
+{
+  "version": 1,
+  "serial": 4,
+  "targets": {
+    "openai_assistants": {
+      "resources": {
+        "agent.weather": {
+          "id": "asst_abc123",
+          "config": { "model": { "id": "gpt-4o-mini", "provider": "openai" } },
+          "dependencies": ["agent.geocoder"]
+        }
+      }
+    }
+  }
+}
+```
+
+**Rules:**
+- `version` is the state format version. Unknown versions are rejected, never guessed at (same stance as language versioning, §9). `serial` increases by one on every write, ordering snapshots.
+- The **unit of remote management is the agent**: each `agent` block is one resource; its model, prompt, and tools are folded into the resource's config (the "agent closure"). Standalone remote tool/prompt objects are deferred.
+- `config` is the **full last-applied config** (canonical JSON, not a hash) — drift reports can then name the attributes that changed without refetching anything.
+- `dependencies` records the resource's managed (agent) dependencies so a resource that has been removed from the spec can still be destroyed in reverse dependency order — the module graph no longer knows it.
+- Serialization is deterministic: stable key order, byte-identical output for equal state. Writes are atomic (temp file + rename) and happen **after every applied operation**, not once at the end — an interrupted apply loses nothing, and a re-run plans exactly the remainder.
+- Like Terraform state, the file is environment-specific and is not meant to be committed.
+
+**Locking:** plan/apply/destroy take a local lock file (`.adl.state.lock`) for their duration; contention errors name the holding pid and the recovery step (delete the stale file). Remote state backends and remote locking are deferred (§7).
+
+### 5.2 Plan/apply semantics
+
+`adl plan` is a **three-way comparison** — spec vs. state vs. remote — and a **pure read**: it issues only `Read`/`Diff` provider calls and never touches the state file.
+
+Per resource, in the module's topological order (deletes first, in reverse dependency order):
+
+| Situation | Plan |
+|-----------|------|
+| in spec, not in state | create ("not in state") |
+| in state, remote object missing | create ("remote object … missing") + drift warning |
+| in spec and state, remote differs from spec | update, with attribute-level diffs |
+| in spec and state, remote matches | no-op |
+| in state, not in spec | delete ("removed from spec") |
+
+**Drift** (remote changed outside adl) is detected by diffing the *last-applied* config against the remote and reported as a warning naming the changed attributes; apply converges the remote back to the spec. When the user instead edits the spec to match a manual remote change, the plan is a no-op and apply silently refreshes the stale state entry (no remote call), so the warning does not recur.
+
+`adl apply` executes the plan in order and stops at the first failure; everything applied up to that point is already saved in state, and the error states what failed, what had been applied, and — if a resource was created remotely but saving state failed — the remote id, so nothing is orphaned silently. `adl apply` does not prompt for confirmation in v0. `adl destroy` deletes everything in state in reverse dependency order.
+
+Diagnostics from plan/apply are structured (severity, block address, summary, detail) so a machine-readable `--json` rendering (§9) is a renderer, not a redesign.
  
 ---
  
@@ -268,6 +320,16 @@ internal/
 ```
  
 Providers implement a common interface (`Read/Create/Update/Delete/Diff`) — later extractable to a plugin system (go-plugin, like Terraform).
+
+**Provider contract** (`internal/provider`): the engine renders each agent's closure into a neutral, serializable config (a JSON value tree — no core Go types, no provider types), so the interface can move behind a plugin boundary without redesign. Contract rules:
+
+- `Read(id)` reports found=false for a resource deleted outside adl — that is drift data, not an error.
+- `Create(resource)` returns the platform's id; the engine records it in state immediately.
+- `Delete(id)` is idempotent: deleting an already-missing remote object succeeds, so re-runs after partial failures converge.
+- `Diff(desired, remote)` is the comparison authority — only the provider knows how the neutral config maps onto its platform's attributes. Empty result = in sync. The engine also diffs the last-applied config against the remote for drift detection.
+- `Diff` must be pure and deterministic; `Read` must not mutate. `adl plan` issues only these two.
+
+The plan/apply engine is target-agnostic and consumes exactly what `adl validate` assembles (loaded module, dependency graph, topological order) plus the state file — the same shape as the codegen engine's `Generate(job)` contract.
  
 ---
  

--- a/cmd/adl/apply.go
+++ b/cmd/adl/apply.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/weirdGuy/agentform/internal/provider"
+)
+
+func newApplyCmd() *cobra.Command {
+	var target string
+	cmd := &cobra.Command{
+		Use:   "apply [--target name] [dir]",
+		Short: "Reconcile platform targets and update the state file",
+		Long:  "apply plans each platform target (exactly like adl plan) and then executes the changes: create, update, and delete remote resources until the platform matches the spec. State is saved after every completed operation, so an interrupted apply loses nothing — re-running plans only the remainder. apply does not prompt for confirmation in v0.",
+		Args:  usageMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runApply(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, target, false)
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "", "apply only the named platform target (default: all platform targets)")
+	return cmd
+}
+
+func newDestroyCmd() *cobra.Command {
+	var target string
+	cmd := &cobra.Command{
+		Use:   "destroy [--target name] [dir]",
+		Short: "Delete every remote resource the state file tracks",
+		Long:  "destroy deletes all managed remote resources of the module's platform targets, in reverse dependency order, and removes them from the state file. Like apply, state is saved after every deletion. destroy does not prompt for confirmation in v0.",
+		Args:  usageMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runApply(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, target, true)
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "", "destroy only the named platform target (default: all platform targets)")
+	return cmd
+}
+
+// runApply reconciles (or destroys) each selected platform target: plan,
+// render, execute. State is persisted through the save closure after every
+// operation; state write failures are IO errors (exit 2), and the engine's
+// error already tells the user what was applied before the failure.
+func runApply(ctx context.Context, stdout, stderr io.Writer, dir, targetName string, destroy bool) error {
+	jobs, release, err := preparePlatform(stderr, dir, targetName)
+	if err != nil {
+		return err
+	}
+	defer releaseAndWarn(stderr, release)
+
+	for i, pj := range jobs {
+		if i > 0 {
+			io.WriteString(stdout, "\n")
+		}
+
+		var plan *provider.Plan
+		if destroy {
+			plan, err = provider.BuildDestroyPlan(pj.job)
+		} else {
+			plan, err = provider.BuildPlan(ctx, pj.provider, pj.job)
+		}
+		if err != nil {
+			return err
+		}
+
+		save := func() error {
+			if err := pj.job.State.Write(dir); err != nil {
+				return withExitCode(2, err)
+			}
+			return nil
+		}
+
+		name := pj.job.Target.Name
+		if destroy {
+			if len(plan.Changes) == 0 {
+				fmt.Fprintf(stdout, "Nothing to destroy for target.%s: the state tracks no resources.\n", name)
+				continue
+			}
+			for _, c := range plan.Changes {
+				fmt.Fprintf(stdout, "  - %s\n", c.Addr)
+			}
+			applied, err := provider.Apply(ctx, pj.provider, pj.job, plan, save)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, "\nDestroyed target.%s: %d deleted.\n", name, applied)
+			continue
+		}
+
+		renderPlan(stdout, plan)
+		if _, err := provider.Apply(ctx, pj.provider, pj.job, plan, save); err != nil {
+			return err
+		}
+		if create, update, del, _ := plan.Counts(); create+update+del > 0 {
+			fmt.Fprintf(stdout, "\nApplied target.%s: %d created, %d updated, %d deleted.\n", name, create, update, del)
+		}
+	}
+	return nil
+}

--- a/cmd/adl/plan.go
+++ b/cmd/adl/plan.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/weirdGuy/agentform/internal/provider"
+)
+
+func newPlanCmd() *cobra.Command {
+	var target string
+	cmd := &cobra.Command{
+		Use:   "plan [--target name] [dir]",
+		Short: "Show what apply would change on the module's platform targets",
+		Long:  "plan runs the full validate pipeline, then compares the spec against the state file and the remote platform (three-way) for each platform target and prints the pending changes. plan is a pure read: it never modifies remote resources or the state file. With --target only the named target is planned; otherwise all platform targets in lexicographic name order.",
+		Args:  usageMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runPlan(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, target)
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "", "plan only the named platform target (default: all platform targets)")
+	return cmd
+}
+
+func runPlan(ctx context.Context, stdout, stderr io.Writer, dir, targetName string) error {
+	jobs, release, err := preparePlatform(stderr, dir, targetName)
+	if err != nil {
+		return err
+	}
+	defer releaseAndWarn(stderr, release)
+
+	for i, pj := range jobs {
+		plan, err := provider.BuildPlan(ctx, pj.provider, pj.job)
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			io.WriteString(stdout, "\n")
+		}
+		renderPlan(stdout, plan)
+	}
+	return nil
+}

--- a/cmd/adl/plan_test.go
+++ b/cmd/adl/plan_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/weirdGuy/agentform/internal/provider"
+	"github.com/weirdGuy/agentform/internal/provider/providertest"
+	"github.com/weirdGuy/agentform/internal/schema"
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// runCLI executes "adl <args>" and returns combined output and the
+// execution error, mirroring runBuildCmd.
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err != nil {
+		fmt.Fprintf(&out, "adl: %v\n", err)
+	}
+	return out.String(), err
+}
+
+// registerFake wires a persistent fake provider under the target name
+// "fake" for the duration of the test, so successive CLI invocations see
+// the same remote platform.
+func registerFake(t *testing.T) *providertest.Fake {
+	t.Helper()
+	fake := providertest.New()
+	providerFactories["fake"] = func(*schema.Target) (provider.Provider, error) { return fake, nil }
+	t.Cleanup(func() { delete(providerFactories, "fake") })
+	return fake
+}
+
+func TestPlanApplyDestroyEndToEnd(t *testing.T) {
+	fake := registerFake(t)
+	dir := copyModule(t, "testdata/platform")
+
+	// 1. First plan: everything is a create; nothing is written.
+	out, err := runCLI(t, "plan", dir)
+	if err != nil {
+		t.Fatalf("plan: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"+ agent.geocoder (not in state)",
+		"+ agent.weather (not in state)",
+		"Plan for target.fake: 2 to create, 0 to update, 0 to delete, 0 unchanged.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan output missing %q:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, state.Filename)); !os.IsNotExist(err) {
+		t.Error("plan created a state file — plan must be a pure read")
+	}
+	if _, err := os.Stat(filepath.Join(dir, state.LockFilename)); !os.IsNotExist(err) {
+		t.Error("plan left the lock file behind")
+	}
+
+	// 2. Apply creates both agents and writes state.
+	out, err = runCLI(t, "apply", dir)
+	if err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	if want := "Applied target.fake: 2 created, 0 updated, 0 deleted."; !strings.Contains(out, want) {
+		t.Errorf("apply output missing %q:\n%s", want, out)
+	}
+	if len(fake.Objects) != 2 {
+		t.Errorf("remote has %d objects after apply, want 2", len(fake.Objects))
+	}
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("loading state after apply: %v", err)
+	}
+	if n := len(st.Target("fake").Resources); n != 2 {
+		t.Errorf("state tracks %d resources, want 2", n)
+	}
+
+	// 3. Replan: in sync.
+	out, err = runCLI(t, "plan", dir)
+	if err != nil {
+		t.Fatalf("replan: %v\n%s", err, out)
+	}
+	if want := "No changes for target.fake: remote matches the spec (2 resources)."; !strings.Contains(out, want) {
+		t.Errorf("replan output missing %q:\n%s", want, out)
+	}
+
+	// 4. Drift: mutate the remote out-of-band; plan warns and converges.
+	for _, obj := range fake.Objects {
+		obj["model"].(map[string]any)["id"] = "tampered"
+		break
+	}
+	out, err = runCLI(t, "plan", dir)
+	if err != nil {
+		t.Fatalf("plan after drift: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"~ agent.",
+		`model.id: "tampered" → "gpt-4o-mini"`,
+		"Warning:",
+		"changed outside adl",
+		"changed attributes: model.id",
+		"Plan for target.fake: 0 to create, 1 to update, 0 to delete, 1 unchanged.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("drift plan output missing %q:\n%s", want, out)
+		}
+	}
+
+	// 5. Apply converges the drift.
+	out, err = runCLI(t, "apply", dir)
+	if err != nil {
+		t.Fatalf("apply after drift: %v\n%s", err, out)
+	}
+	if want := "Applied target.fake: 0 created, 1 updated, 0 deleted."; !strings.Contains(out, want) {
+		t.Errorf("apply output missing %q:\n%s", want, out)
+	}
+
+	// 6. Destroy removes everything, remotely and from state.
+	out, err = runCLI(t, "destroy", dir)
+	if err != nil {
+		t.Fatalf("destroy: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"- agent.weather",
+		"- agent.geocoder",
+		"Destroyed target.fake: 2 deleted.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("destroy output missing %q:\n%s", want, out)
+		}
+	}
+	if len(fake.Objects) != 0 {
+		t.Errorf("remote still has %d objects after destroy", len(fake.Objects))
+	}
+	st, err = state.Load(dir)
+	if err != nil {
+		t.Fatalf("loading state after destroy: %v", err)
+	}
+	if n := len(st.Target("fake").Resources); n != 0 {
+		t.Errorf("state still tracks %d resources after destroy", n)
+	}
+
+	// 7. Destroy again: nothing left to do.
+	out, err = runCLI(t, "destroy", dir)
+	if err != nil {
+		t.Fatalf("second destroy: %v\n%s", err, out)
+	}
+	if want := "Nothing to destroy for target.fake"; !strings.Contains(out, want) {
+		t.Errorf("second destroy output missing %q:\n%s", want, out)
+	}
+}
+
+func TestPlatformCommandErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		dir      string
+		lockDir  bool // pre-create the lock file in a module copy
+		wantCode int
+		wantOut  []string
+	}{
+		{
+			name:     "codegen target directs to adl build",
+			args:     []string{"plan", "--target", "langgraph"},
+			dir:      "testdata/valid",
+			wantCode: 2,
+			wantOut:  []string{"target.langgraph", "codegen", "adl build"},
+		},
+		{
+			name:     "unknown target is a usage error",
+			args:     []string{"plan", "--target", "nope"},
+			dir:      "testdata/platform",
+			wantCode: 2,
+			wantOut:  []string{"target.nope", "not declared"},
+		},
+		{
+			name:     "zero platform targets is a usage error",
+			args:     []string{"apply"},
+			dir:      "testdata/valid",
+			wantCode: 2,
+			wantOut:  []string{"no platform targets"},
+		},
+		{
+			name:     "platform target without a registered provider",
+			args:     []string{"plan"},
+			dir:      "testdata/platform_no_provider",
+			wantCode: 1,
+			wantOut:  []string{"target.openai_assistants", "no platform provider"},
+		},
+		{
+			name:     "invalid module never plans",
+			args:     []string{"plan"},
+			dir:      "testdata/unknown_ref",
+			wantCode: 1,
+			wantOut:  []string{"unknown reference"},
+		},
+		{
+			name:     "held lock is reported with recovery hint",
+			args:     []string{"plan"},
+			dir:      "testdata/platform",
+			lockDir:  true,
+			wantCode: 2,
+			wantOut:  []string{"locked", "delete"},
+		},
+	}
+
+	registerFake(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.dir
+			if tt.lockDir {
+				dir = copyModule(t, tt.dir)
+				if err := os.WriteFile(filepath.Join(dir, state.LockFilename), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			out, err := runCLI(t, append(tt.args, dir)...)
+			if err == nil {
+				t.Fatalf("command succeeded, want error\noutput:\n%s", out)
+			}
+			if code := exitCode(err); code != tt.wantCode {
+				t.Errorf("exit code = %d, want %d (error: %v)", code, tt.wantCode, err)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}

--- a/cmd/adl/platform.go
+++ b/cmd/adl/platform.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/weirdGuy/agentform/internal/module"
+	"github.com/weirdGuy/agentform/internal/provider"
+	"github.com/weirdGuy/agentform/internal/schema"
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// providerFactories maps a platform target's name to its provider factory:
+// the target label doubles as the provider selector, exactly like codegen
+// target names select generators (see cmd/adl/build.go). Issue #16
+// registers "openai_assistants" here.
+var providerFactories = map[string]func(*schema.Target) (provider.Provider, error){}
+
+// platformJob is one reconcile unit: a platform target with its resolved
+// provider, sharing the module, graph, and state with its siblings.
+type platformJob struct {
+	job      *provider.Job
+	provider provider.Provider
+}
+
+// preparePlatform runs the shared front half of plan/apply/destroy:
+// validate the module, select the platform targets, resolve their
+// providers, take the state lock, and load the state file. The returned
+// release function must be called (once) when the command is done.
+func preparePlatform(stderr io.Writer, dir, targetName string) (jobs []*platformJob, release func() error, err error) {
+	mod, g, err := compileModule(stderr, dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	targets, err := selectPlatformTargets(mod, targetName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Resolve providers before locking: a missing provider needs no lock.
+	var resolved []*platformJob
+	for _, tgt := range targets {
+		p, err := providerFor(tgt)
+		if err != nil {
+			return nil, nil, err
+		}
+		resolved = append(resolved, &platformJob{
+			job:      &provider.Job{Module: mod, Graph: g, Target: tgt},
+			provider: p,
+		})
+	}
+
+	release, err = state.Lock(dir)
+	if err != nil {
+		return nil, nil, withExitCode(2, err)
+	}
+	st, err := state.Load(dir)
+	if err != nil {
+		release()
+		return nil, nil, err
+	}
+	for _, pj := range resolved {
+		pj.job.State = st
+	}
+	return resolved, release, nil
+}
+
+// selectPlatformTargets picks the platform targets to reconcile: the named
+// one, or all of them in lexicographic name order when no name is given.
+// Selection failures are usage errors (exit 2), mirroring adl build.
+func selectPlatformTargets(mod *module.Module, name string) ([]*schema.Target, error) {
+	if name != "" {
+		for _, tgt := range mod.Targets {
+			if tgt.Name != name {
+				continue
+			}
+			if tgt.Type != "platform" {
+				return nil, usageErrorf("target.%s is a %s target; adl plan/apply only reconcile platform targets — use adl build for it", name, tgt.Type)
+			}
+			return []*schema.Target{tgt}, nil
+		}
+		return nil, usageErrorf("target.%s: not declared in the module (platform targets: %s)", name, joinOrNone(platformNames(mod)))
+	}
+
+	var targets []*schema.Target
+	for _, tgt := range mod.Targets {
+		if tgt.Type == "platform" {
+			targets = append(targets, tgt)
+		}
+	}
+	if len(targets) == 0 {
+		return nil, usageErrorf("module declares no platform targets; adl plan/apply need at least one target with type = \"platform\"")
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i].Name < targets[j].Name })
+	return targets, nil
+}
+
+func platformNames(mod *module.Module) []string {
+	var names []string
+	for _, tgt := range mod.Targets {
+		if tgt.Type == "platform" {
+			names = append(names, tgt.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// providerFor resolves a platform target's provider from the registry.
+func providerFor(tgt *schema.Target) (provider.Provider, error) {
+	factory, ok := providerFactories[tgt.Name]
+	if !ok {
+		return nil, fmt.Errorf("%s: no platform provider named %q (available: %s)", tgt.Addr(), tgt.Name, joinOrNone(providerNames()))
+	}
+	p, err := factory(tgt)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", tgt.Addr(), err)
+	}
+	return p, nil
+}
+
+func providerNames() []string {
+	names := make([]string, 0, len(providerFactories))
+	for name := range providerFactories {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// renderPlan prints a plan: one line per pending change with attribute
+// diffs under updates, drift warnings, then the countable summary line.
+func renderPlan(w io.Writer, p *provider.Plan) {
+	create, update, del, noop := p.Counts()
+
+	for _, c := range p.Changes {
+		switch c.Action {
+		case provider.ActionCreate:
+			fmt.Fprintf(w, "  + %s (%s)\n", c.Addr, c.Reason)
+		case provider.ActionUpdate:
+			fmt.Fprintf(w, "  ~ %s\n", c.Addr)
+			for _, d := range c.Diffs {
+				fmt.Fprintf(w, "      %s: %s → %s\n", d.Path, renderValue(d.Old), renderValue(d.New))
+			}
+		case provider.ActionDelete:
+			fmt.Fprintf(w, "  - %s (%s)\n", c.Addr, c.Reason)
+		}
+	}
+	if create+update+del > 0 {
+		fmt.Fprintln(w)
+	}
+
+	renderDiagnostics(w, p.Diagnostics)
+
+	if create+update+del == 0 {
+		fmt.Fprintf(w, "No changes for target.%s: remote matches the spec (%s).\n", p.Target, countNoun(noop, "resource"))
+		return
+	}
+	fmt.Fprintf(w, "Plan for target.%s: %d to create, %d to update, %d to delete, %d unchanged.\n", p.Target, create, update, del, noop)
+}
+
+func renderDiagnostics(w io.Writer, diags []provider.Diagnostic) {
+	for _, d := range diags {
+		line := fmt.Sprintf("%s: %s", d.Addr, d.Summary)
+		if d.Addr == "" {
+			line = d.Summary
+		}
+		if d.Detail != "" {
+			line += " (" + d.Detail + ")"
+		}
+		switch d.Severity {
+		case provider.SeverityWarning:
+			fmt.Fprintf(w, "Warning: %s\n", line)
+		default:
+			fmt.Fprintf(w, "Error: %s\n", line)
+		}
+	}
+	if len(diags) > 0 {
+		fmt.Fprintln(w)
+	}
+}
+
+// renderValue formats one attribute value for plan output: compact JSON,
+// truncated so a prompt body cannot flood the plan.
+func renderValue(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	const limit = 60
+	if len(data) > limit {
+		return string(data[:limit-1]) + "…"
+	}
+	return string(data)
+}
+
+// releaseAndWarn releases the state lock, downgrading a release failure to
+// a warning — the command's real result must not be masked by it.
+func releaseAndWarn(stderr io.Writer, release func() error) {
+	if err := release(); err != nil {
+		fmt.Fprintf(stderr, "adl: warning: %v\n", err)
+	}
+}

--- a/cmd/adl/root.go
+++ b/cmd/adl/root.go
@@ -29,6 +29,9 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newValidateCmd())
 	root.AddCommand(newBuildCmd())
+	root.AddCommand(newPlanCmd())
+	root.AddCommand(newApplyCmd())
+	root.AddCommand(newDestroyCmd())
 	root.AddCommand(newFmtCmd())
 	return root
 }

--- a/cmd/adl/testdata/platform/adl.hcl
+++ b/cmd/adl/testdata/platform/adl.hcl
@@ -1,0 +1,8 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "fake" {
+  type = "platform"
+}

--- a/cmd/adl/testdata/platform/agents.agent
+++ b/cmd/adl/testdata/platform/agents.agent
@@ -1,0 +1,24 @@
+agent "geocoder" {
+  model = model.fast
+
+  input "place" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}
+
+agent "weather" {
+  model = model.fast
+
+  input "coordinates" {
+    type    = string
+    default = agent.geocoder.output.coordinates
+  }
+
+  output "report" {
+    type = string
+  }
+}

--- a/cmd/adl/testdata/platform_no_provider/adl.hcl
+++ b/cmd/adl/testdata/platform_no_provider/adl.hcl
@@ -1,0 +1,8 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "openai_assistants" {
+  type = "platform"
+}

--- a/cmd/adl/testdata/platform_no_provider/solo.agent
+++ b/cmd/adl/testdata/platform_no_provider/solo.agent
@@ -1,0 +1,7 @@
+agent "solo" {
+  model = model.fast
+
+  output "answer" {
+    type = string
+  }
+}

--- a/internal/provider/apply.go
+++ b/internal/provider/apply.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// ApplyError reports the change that stopped an apply. Everything before
+// it was applied and saved to state — a re-run plans only the remainder.
+type ApplyError struct {
+	Addr    string // block address of the failed change
+	Action  Action
+	Applied int // changes completed before the failure
+	Total   int // changes the plan wanted (noops excluded)
+	Err     error
+}
+
+func (e *ApplyError) Error() string {
+	return fmt.Sprintf("%s: %s failed (%d of %d changes applied, state saved): %v",
+		e.Addr, e.Action, e.Applied, e.Total, e.Err)
+}
+
+func (e *ApplyError) Unwrap() error { return e.Err }
+
+// Apply executes a plan's changes in order, persisting state via save
+// after every completed operation, so a failure or crash never loses the
+// mapping of what already exists remotely. The first failure aborts with
+// an *ApplyError; earlier changes stay applied and saved.
+//
+// Noops are free with one exception: when the state's recorded config is
+// stale even though the remote matches the spec (the user aligned the spec
+// with a manual remote change), the state entry is refreshed — without any
+// remote call — so the drift warning does not recur forever.
+func Apply(ctx context.Context, p Provider, job *Job, plan *Plan, save func() error) (applied int, err error) {
+	_, _, _, noops := plan.Counts()
+	total := len(plan.Changes) - noops
+	ts := job.State.Target(job.Target.Name)
+
+	fail := func(c Change, err error) (int, error) {
+		return applied, &ApplyError{Addr: c.Addr, Action: c.Action, Applied: applied, Total: total, Err: err}
+	}
+
+	for _, c := range plan.Changes {
+		switch c.Action {
+		case ActionCreate:
+			desired, err := desiredResource(job, c.Addr)
+			if err != nil {
+				return fail(c, err)
+			}
+			id, err := p.Create(ctx, desired)
+			if err != nil {
+				return fail(c, err)
+			}
+			res, err := stateEntry(job, id, desired)
+			if err != nil {
+				return fail(c, err)
+			}
+			ts.Resources[c.Addr] = res
+			if err := save(); err != nil {
+				return fail(c, fmt.Errorf("created remotely as %s, but saving state failed — record the id manually or re-run after fixing: %w", id, err))
+			}
+			applied++
+
+		case ActionUpdate:
+			desired, err := desiredResource(job, c.Addr)
+			if err != nil {
+				return fail(c, err)
+			}
+			if err := p.Update(ctx, c.ID, desired); err != nil {
+				return fail(c, err)
+			}
+			res, err := stateEntry(job, c.ID, desired)
+			if err != nil {
+				return fail(c, err)
+			}
+			ts.Resources[c.Addr] = res
+			if err := save(); err != nil {
+				return fail(c, fmt.Errorf("updated remotely, but saving state failed: %w", err))
+			}
+			applied++
+
+		case ActionDelete:
+			if err := p.Delete(ctx, c.ID); err != nil {
+				return fail(c, err)
+			}
+			delete(ts.Resources, c.Addr)
+			if err := save(); err != nil {
+				return fail(c, fmt.Errorf("deleted remotely, but saving state failed: %w", err))
+			}
+			applied++
+
+		case ActionNoop:
+			refreshed, err := refreshStale(job, ts, c.Addr)
+			if err != nil {
+				return fail(c, err)
+			}
+			if refreshed {
+				if err := save(); err != nil {
+					return fail(c, fmt.Errorf("refreshing state failed: %w", err))
+				}
+			}
+		}
+	}
+	return applied, nil
+}
+
+// stateEntry builds the state record for a just-applied resource: remote
+// id, canonical config, and its managed dependencies from the graph.
+func stateEntry(job *Job, id string, desired *Resource) (*state.Resource, error) {
+	raw, err := MarshalConfig(desired.Config)
+	if err != nil {
+		return nil, err
+	}
+	var deps []string
+	for _, dep := range job.Graph.Dependencies(desired.Addr) {
+		if strings.HasPrefix(dep, "agent.") {
+			deps = append(deps, dep)
+		}
+	}
+	return &state.Resource{ID: id, Config: raw, Dependencies: deps}, nil
+}
+
+// refreshStale rewrites a noop resource's state entry when its recorded
+// config no longer matches the spec, reporting whether it did.
+func refreshStale(job *Job, ts *state.TargetState, addr string) (bool, error) {
+	res, ok := ts.Resources[addr]
+	if !ok {
+		return false, nil
+	}
+	desired, err := desiredResource(job, addr)
+	if err != nil {
+		return false, err
+	}
+	stale, err := configStale(desired, res.Config)
+	if err != nil || !stale {
+		return false, err
+	}
+	fresh, err := stateEntry(job, res.ID, desired)
+	if err != nil {
+		return false, err
+	}
+	ts.Resources[addr] = fresh
+	return true, nil
+}

--- a/internal/provider/apply_test.go
+++ b/internal/provider/apply_test.go
@@ -1,0 +1,309 @@
+package provider_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/provider"
+	"github.com/weirdGuy/agentform/internal/provider/providertest"
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// countingSave returns a save callback that counts invocations.
+func countingSave(n *int) func() error {
+	return func() error {
+		*n++
+		return nil
+	}
+}
+
+func buildPlan(t *testing.T, fake *providertest.Fake, job *provider.Job) *provider.Plan {
+	t.Helper()
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	return plan
+}
+
+func TestApplyFreshModuleCreatesEverything(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	plan := buildPlan(t, fake, job)
+
+	var saves int
+	applied, err := provider.Apply(context.Background(), fake, job, plan, countingSave(&saves))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if applied != 3 {
+		t.Errorf("applied = %d, want 3", applied)
+	}
+	if saves != 3 {
+		t.Errorf("state saved %d times, want once per change", saves)
+	}
+
+	wantCalls := []string{"create agent.geocoder", "create agent.forecast", "create agent.weather"}
+	if diff := cmp.Diff(wantCalls, fake.Calls); diff != "" {
+		t.Errorf("provider calls (-want +got):\n%s", diff)
+	}
+
+	ts := job.State.Target("fake")
+	wantState := map[string]struct {
+		id   string
+		deps []string
+	}{
+		"agent.geocoder": {id: "fake-1"},
+		"agent.forecast": {id: "fake-2", deps: []string{"agent.geocoder"}},
+		"agent.weather":  {id: "fake-3", deps: []string{"agent.forecast", "agent.geocoder"}},
+	}
+	for addr, want := range wantState {
+		res, ok := ts.Resources[addr]
+		if !ok {
+			t.Errorf("state has no %s", addr)
+			continue
+		}
+		if res.ID != want.id {
+			t.Errorf("%s: ID = %q, want %q", addr, res.ID, want.id)
+		}
+		if diff := cmp.Diff(want.deps, res.Dependencies); diff != "" {
+			t.Errorf("%s: dependencies (-want +got):\n%s", addr, diff)
+		}
+		if len(res.Config) == 0 {
+			t.Errorf("%s: no last-applied config recorded", addr)
+		}
+	}
+
+	// The follow-up plan must be all noops.
+	fake.Calls = nil
+	replan := buildPlan(t, fake, job)
+	if c, u, d, n := replan.Counts(); c != 0 || u != 0 || d != 0 || n != 3 {
+		t.Errorf("replan counts = %d,%d,%d,%d; want 0,0,0,3", c, u, d, n)
+	}
+}
+
+func TestApplyPartialFailureThenRecovery(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	boom := errors.New("quota exceeded")
+	fake.FailOn = map[string]error{"create agent.forecast": boom}
+
+	var saves int
+	applied, err := provider.Apply(context.Background(), fake, job, buildPlan(t, fake, job), countingSave(&saves))
+	if err == nil {
+		t.Fatal("Apply succeeded, want error")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error %v does not wrap the provider error", err)
+	}
+	var applyErr *provider.ApplyError
+	if !errors.As(err, &applyErr) {
+		t.Fatalf("error %T is not an *ApplyError", err)
+	}
+	if applyErr.Addr != "agent.forecast" || applyErr.Action != provider.ActionCreate || applyErr.Applied != 1 {
+		t.Errorf("ApplyError = %+v; want addr agent.forecast, action create, 1 applied", applyErr)
+	}
+	if applied != 1 || saves != 1 {
+		t.Errorf("applied = %d, saves = %d; want 1, 1", applied, saves)
+	}
+	// The message tells the user where it stopped and what happened.
+	for _, want := range []string{"agent.forecast", "create", "1 of 3", "quota exceeded"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+
+	// What landed before the failure is in state...
+	ts := job.State.Target("fake")
+	if _, ok := ts.Resources["agent.geocoder"]; !ok {
+		t.Error("agent.geocoder missing from state after partial apply")
+	}
+	if _, ok := ts.Resources["agent.forecast"]; ok {
+		t.Error("failed agent.forecast landed in state")
+	}
+
+	// ...and a re-run picks up exactly the remaining work.
+	fake.FailOn = nil
+	fake.Calls = nil
+	replan := buildPlan(t, fake, job)
+	var wantReplan = []string{"noop agent.geocoder", "create agent.forecast", "create agent.weather"}
+	if diff := cmp.Diff(wantReplan, changeSummary(replan)); diff != "" {
+		t.Errorf("replan (-want +got):\n%s", diff)
+	}
+	applied, err = provider.Apply(context.Background(), fake, job, replan, countingSave(&saves))
+	if err != nil {
+		t.Fatalf("recovery Apply: %v", err)
+	}
+	if applied != 2 {
+		t.Errorf("recovery applied = %d, want 2", applied)
+	}
+}
+
+func TestApplySaveFailureNamesTheRemoteID(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	diskFull := errors.New("disk full")
+
+	_, err := provider.Apply(context.Background(), fake, job, buildPlan(t, fake, job), func() error { return diskFull })
+	if err == nil {
+		t.Fatal("Apply succeeded, want error")
+	}
+	if !errors.Is(err, diskFull) {
+		t.Errorf("error %v does not wrap the save error", err)
+	}
+	// The remote object exists but state does not know: the error must
+	// hand the user the id.
+	for _, want := range []string{"agent.geocoder", "fake-1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestApplyUpdateConvergesRemoteAndState(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	ids := seedAll(t, job, fake)
+
+	// Remote drifted; the plan converges it back to the spec.
+	fake.Objects[ids["agent.weather"]]["instructions"] = "hacked"
+
+	var saves int
+	applied, err := provider.Apply(context.Background(), fake, job, buildPlan(t, fake, job), countingSave(&saves))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if applied != 1 || saves != 1 {
+		t.Errorf("applied = %d, saves = %d; want 1, 1", applied, saves)
+	}
+	remote, _, _ := fake.Read(context.Background(), ids["agent.weather"])
+	if remote["instructions"] == "hacked" {
+		t.Error("remote object was not converged back to the spec")
+	}
+}
+
+func TestApplyDeleteRemovedResource(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+
+	ts := job.State.Target("fake")
+	ts.Resources["agent.legacy"] = &state.Resource{ID: "fake-99", Config: json.RawMessage(`{}`)}
+	fake.Objects["fake-99"] = provider.Object{}
+
+	applied, err := provider.Apply(context.Background(), fake, job, buildPlan(t, fake, job), countingSave(new(int)))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if applied != 1 {
+		t.Errorf("applied = %d, want 1", applied)
+	}
+	if _, ok := ts.Resources["agent.legacy"]; ok {
+		t.Error("deleted resource still tracked in state")
+	}
+	if _, ok := fake.Objects["fake-99"]; ok {
+		t.Error("remote object still exists after delete")
+	}
+}
+
+func TestApplyDeleteOfMissingRemoteStillCleansState(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+
+	// Tracked in state, gone from the platform, and gone from the spec:
+	// the delete must still succeed and clean up state.
+	ts := job.State.Target("fake")
+	ts.Resources["agent.legacy"] = &state.Resource{ID: "fake-99", Config: json.RawMessage(`{}`)}
+
+	applied, err := provider.Apply(context.Background(), fake, job, buildPlan(t, fake, job), countingSave(new(int)))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if applied != 1 {
+		t.Errorf("applied = %d, want 1", applied)
+	}
+	if _, ok := ts.Resources["agent.legacy"]; ok {
+		t.Error("resource with missing remote still tracked in state")
+	}
+}
+
+func TestApplyNoopRefreshesStaleStateConfig(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+
+	// State recorded an older config, but remote already matches the spec
+	// (user aligned the spec with a manual change). Apply must refresh the
+	// state entry without touching the remote.
+	ts := job.State.Target("fake")
+	var cfg provider.Object
+	if err := json.Unmarshal(ts.Resources["agent.geocoder"].Config, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfg["model"].(map[string]any)["id"] = "gpt-4o"
+	staleRaw, _ := provider.MarshalConfig(cfg)
+	ts.Resources["agent.geocoder"].Config = staleRaw
+
+	plan := buildPlan(t, fake, job)
+	fake.Calls = nil
+
+	var saves int
+	applied, err := provider.Apply(context.Background(), fake, job, plan, countingSave(&saves))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 (refresh is not a remote change)", applied)
+	}
+	if saves != 1 {
+		t.Errorf("saves = %d, want 1 (the refreshed entry must be persisted)", saves)
+	}
+	if len(fake.Calls) != 0 {
+		t.Errorf("noop refresh touched the provider: %v", fake.Calls)
+	}
+	if string(ts.Resources["agent.geocoder"].Config) == string(staleRaw) {
+		t.Error("stale state config was not refreshed")
+	}
+
+	// Drift warning must not recur once state is refreshed.
+	replan := buildPlan(t, fake, job)
+	if len(replan.Diagnostics) != 0 {
+		t.Errorf("drift warning recurred after refresh: %+v", replan.Diagnostics)
+	}
+}
+
+func TestApplyDestroyEmptiesState(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+	fake.Calls = nil
+
+	plan, err := provider.BuildDestroyPlan(job)
+	if err != nil {
+		t.Fatalf("BuildDestroyPlan: %v", err)
+	}
+	applied, err := provider.Apply(context.Background(), fake, job, plan, countingSave(new(int)))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if applied != 3 {
+		t.Errorf("applied = %d, want 3", applied)
+	}
+
+	wantCalls := []string{"delete fake-3", "delete fake-2", "delete fake-1"}
+	if diff := cmp.Diff(wantCalls, fake.Calls); diff != "" {
+		t.Errorf("provider calls (-want +got):\n%s", diff)
+	}
+	if n := len(job.State.Target("fake").Resources); n != 0 {
+		t.Errorf("state still tracks %d resources after destroy", n)
+	}
+	if n := len(fake.Objects); n != 0 {
+		t.Errorf("%d remote objects remain after destroy", n)
+	}
+}

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -1,0 +1,158 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/weirdGuy/agentform/internal/module"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+// DesiredConfig renders one agent's closure — the agent block plus the
+// model, prompt, and tools it references — into the neutral configuration
+// providers consume. Optional fields are omitted when empty. The result is
+// normalized through a JSON round-trip so every number is a float64 and
+// equality never depends on Go-side types.
+//
+// An input default that references another agent's output is deliberately
+// not part of the config: references are ordering-only in v0 (SPEC.md §4),
+// so changing one must not read as a remote update.
+func DesiredConfig(mod *module.Module, a *schema.Agent) (Object, error) {
+	cfg := map[string]any{}
+	if a.Description != "" {
+		cfg["description"] = a.Description
+	}
+
+	mdl, err := lookupBlock[*schema.Model](mod, a, a.Model)
+	if err != nil {
+		return nil, err
+	}
+	modelCfg := map[string]any{"provider": mdl.Provider, "id": mdl.ID}
+	if len(mdl.Params) > 0 {
+		modelCfg["params"] = mdl.Params
+	}
+	cfg["model"] = modelCfg
+
+	if a.SystemPrompt != "" {
+		prompt, err := lookupBlock[*schema.Prompt](mod, a, a.SystemPrompt)
+		if err != nil {
+			return nil, err
+		}
+		cfg["instructions"] = prompt.Body
+	}
+
+	var tools []any
+	for _, ref := range a.Tools {
+		tool, err := lookupBlock[*schema.Tool](mod, a, ref)
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, toolConfig(tool))
+	}
+	if len(tools) > 0 {
+		cfg["tools"] = tools
+	}
+
+	var inputs []any
+	for _, in := range a.Inputs {
+		ic := map[string]any{"name": in.Name, "type": in.Type}
+		if in.Description != "" {
+			ic["description"] = in.Description
+		}
+		if in.Optional {
+			ic["optional"] = true
+		}
+		if in.Default != nil {
+			ic["default"] = in.Default
+		}
+		inputs = append(inputs, ic)
+	}
+	if len(inputs) > 0 {
+		cfg["inputs"] = inputs
+	}
+
+	var outputs []any
+	for _, out := range a.Outputs {
+		oc := map[string]any{"name": out.Name, "type": out.Type}
+		if out.Description != "" {
+			oc["description"] = out.Description
+		}
+		outputs = append(outputs, oc)
+	}
+	if len(outputs) > 0 {
+		cfg["outputs"] = outputs
+	}
+
+	return normalize(cfg)
+}
+
+// toolConfig renders one tool's interface + source.
+func toolConfig(t *schema.Tool) map[string]any {
+	tc := map[string]any{"name": t.Name}
+	if t.Description != "" {
+		tc["description"] = t.Description
+	}
+	var params []any
+	for _, p := range t.Params {
+		pc := map[string]any{"name": p.Name, "type": p.Type}
+		if p.Description != "" {
+			pc["description"] = p.Description
+		}
+		if p.Default != nil {
+			pc["default"] = p.Default
+		}
+		params = append(params, pc)
+	}
+	if len(params) > 0 {
+		tc["params"] = params
+	}
+	tc["returns"] = map[string]any{"type": t.Returns.Type}
+	src := map[string]any{"kind": t.Source.Kind}
+	if t.Source.URI != "" {
+		src["uri"] = t.Source.URI
+	}
+	tc["source"] = src
+	return tc
+}
+
+// MarshalConfig serializes a config canonically: encoding/json sorts map
+// keys, so equal configs always produce identical bytes. This is the form
+// stored in the state file and compared for staleness.
+func MarshalConfig(o Object) (json.RawMessage, error) {
+	data, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("encoding config: %w", err)
+	}
+	return data, nil
+}
+
+// normalize round-trips a value tree through JSON so it lands exactly on
+// the encoding/json value model (all numbers float64).
+func normalize(cfg map[string]any) (Object, error) {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("encoding config: %w", err)
+	}
+	var out Object
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("normalizing config: %w", err)
+	}
+	return out, nil
+}
+
+// lookupBlock resolves a reference from an agent against the module and
+// asserts its block type. Failures here mean the module was not run through
+// the validate pipeline first — that is a bug in the caller, but it still
+// surfaces as a diagnostic with the block address rather than a panic.
+func lookupBlock[T any](mod *module.Module, a *schema.Agent, ref string) (T, error) {
+	var zero T
+	sym, ok := mod.Lookup(ref)
+	if !ok {
+		return zero, fmt.Errorf("%s: unknown reference %s", a.Addr(), ref)
+	}
+	block, ok := sym.Block.(T)
+	if !ok {
+		return zero, fmt.Errorf("%s: reference %s is not the expected block kind", a.Addr(), ref)
+	}
+	return block, nil
+}

--- a/internal/provider/config_test.go
+++ b/internal/provider/config_test.go
@@ -1,0 +1,128 @@
+package provider_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/module"
+	"github.com/weirdGuy/agentform/internal/provider"
+	"github.com/weirdGuy/agentform/internal/schema"
+)
+
+func loadModule(t *testing.T, dir string) *module.Module {
+	t.Helper()
+	mod, err := module.Load(filepath.Join("testdata", dir))
+	if err != nil {
+		t.Fatalf("Load(%s): unexpected error: %v", dir, err)
+	}
+	return mod
+}
+
+func agentByAddr(t *testing.T, mod *module.Module, addr string) *schema.Agent {
+	t.Helper()
+	sym, ok := mod.Lookup(addr)
+	if !ok {
+		t.Fatalf("module has no %s", addr)
+	}
+	return sym.Block.(*schema.Agent)
+}
+
+func TestDesiredConfig(t *testing.T) {
+	mod := loadModule(t, "weather")
+
+	tests := []struct {
+		addr string
+		want provider.Object
+	}{
+		{
+			// Full closure: description, model params, instructions from the
+			// prompt body, tools, mixed inputs, outputs. All numbers are
+			// float64 — the JSON value model.
+			addr: "agent.weather",
+			want: provider.Object{
+				"description": "Answers weather questions",
+				"model": map[string]any{
+					"provider": "openai",
+					"id":       "gpt-4o-mini",
+					"params":   map[string]any{"temperature": 0.2, "max_tokens": float64(4096)},
+				},
+				"instructions": "You are a weather assistant for {{location}}.\n",
+				"tools": []any{
+					map[string]any{
+						"name":        "web_search",
+						"description": "Search the web",
+						"params": []any{
+							map[string]any{"name": "query", "type": "string", "description": "The query to search for"},
+							map[string]any{"name": "max_results", "type": "number", "default": float64(10)},
+						},
+						"returns": map[string]any{"type": "string"},
+						"source":  map[string]any{"kind": "mcp", "uri": "mcp://search-server/web_search"},
+					},
+				},
+				"inputs": []any{
+					map[string]any{"name": "location", "type": "string", "description": "The location to get the weather for"},
+					map[string]any{"name": "date", "type": "string", "optional": true},
+					// forecast_context's default is a cross-agent output
+					// reference: ordering-only in v0, so it must not appear
+					// in the config (a ref change must not cause an update).
+					map[string]any{"name": "forecast_context", "type": "string"},
+				},
+				"outputs": []any{
+					map[string]any{"name": "report", "type": "string"},
+				},
+			},
+		},
+		{
+			// Minimal agent: no description, no prompt, no tools — the keys
+			// are omitted, not present with empty values.
+			addr: "agent.geocoder",
+			want: provider.Object{
+				"model": map[string]any{
+					"provider": "openai",
+					"id":       "gpt-4o-mini",
+					"params":   map[string]any{"temperature": 0.2, "max_tokens": float64(4096)},
+				},
+				"inputs":  []any{map[string]any{"name": "place", "type": "string"}},
+				"outputs": []any{map[string]any{"name": "coordinates", "type": "string"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			got, err := provider.DesiredConfig(mod, agentByAddr(t, mod, tt.addr))
+			if err != nil {
+				t.Fatalf("DesiredConfig: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("DesiredConfig(%s) (-want +got):\n%s", tt.addr, diff)
+			}
+		})
+	}
+}
+
+func TestMarshalConfigIsDeterministic(t *testing.T) {
+	mod := loadModule(t, "weather")
+	a := agentByAddr(t, mod, "agent.weather")
+
+	var first []byte
+	for i := 0; i < 5; i++ {
+		cfg, err := provider.DesiredConfig(mod, a)
+		if err != nil {
+			t.Fatalf("DesiredConfig #%d: %v", i+1, err)
+		}
+		raw, err := provider.MarshalConfig(cfg)
+		if err != nil {
+			t.Fatalf("MarshalConfig #%d: %v", i+1, err)
+		}
+		if i == 0 {
+			first = raw
+			continue
+		}
+		if string(raw) != string(first) {
+			t.Fatalf("MarshalConfig is not deterministic (run 1 vs run %d):\n%s\nvs:\n%s", i+1, first, raw)
+		}
+	}
+}

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -1,0 +1,324 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/weirdGuy/agentform/internal/graph"
+	"github.com/weirdGuy/agentform/internal/module"
+	"github.com/weirdGuy/agentform/internal/schema"
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// Action is what apply will do to one resource.
+type Action string
+
+const (
+	ActionCreate Action = "create"
+	ActionUpdate Action = "update"
+	ActionDelete Action = "delete"
+	ActionNoop   Action = "noop"
+)
+
+// Change is one planned operation on one resource.
+type Change struct {
+	Addr   string     `json:"addr"`
+	Action Action     `json:"action"`
+	ID     string     `json:"id,omitempty"`     // remote id; empty for creates
+	Reason string     `json:"reason,omitempty"` // why this action was chosen
+	Diffs  []AttrDiff `json:"diffs,omitempty"`  // desired vs. remote (updates)
+	Drift  []AttrDiff `json:"drift,omitempty"`  // last-applied vs. remote (informational)
+}
+
+// Severity classifies a diagnostic.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Diagnostic is a structured plan/apply finding: what was found, what was
+// expected, and where. The JSON tags are the future --json rendering
+// (SPEC.md §9); the CLI renders the same fields as text.
+type Diagnostic struct {
+	Severity Severity `json:"severity"`
+	Addr     string   `json:"addr,omitempty"` // block address, empty when module-wide
+	Summary  string   `json:"summary"`        // what was found
+	Detail   string   `json:"detail,omitempty"`
+}
+
+// Plan is the result of the three-way comparison (spec vs. state vs.
+// remote) for one platform target. Changes are in execution order: deletes
+// first in reverse dependency order, then creates/updates/noops in the
+// module's topological order.
+type Plan struct {
+	Target      string       `json:"target"`
+	Changes     []Change     `json:"changes"`
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+// Counts tallies the plan's actions.
+func (p *Plan) Counts() (create, update, del, noop int) {
+	for _, c := range p.Changes {
+		switch c.Action {
+		case ActionCreate:
+			create++
+		case ActionUpdate:
+			update++
+		case ActionDelete:
+			del++
+		case ActionNoop:
+			noop++
+		}
+	}
+	return create, update, del, noop
+}
+
+// Job bundles what the engine consumes: the validated module, its graph,
+// the platform target being reconciled, and the loaded state file — the
+// same pipeline output adl validate assembles, plus state.
+type Job struct {
+	Module *module.Module
+	Graph  *graph.Graph
+	Target *schema.Target
+	State  *state.File
+}
+
+// BuildPlan performs the three-way comparison for one platform target.
+// It is a pure read: only Read and Diff are called on the provider, and
+// the state file is never modified.
+//
+// Per resource: absent from state → create; tracked but the remote object
+// is gone → create (with a drift warning); otherwise the provider's Diff
+// against the desired config decides update vs. noop, and its Diff against
+// the last-applied config detects drift (remote changed outside adl).
+func BuildPlan(ctx context.Context, p Provider, job *Job) (*Plan, error) {
+	plan := &Plan{Target: job.Target.Name}
+	resources := stateResources(job)
+
+	deletes, err := removedFromSpec(job, resources)
+	if err != nil {
+		return nil, err
+	}
+	plan.Changes = append(plan.Changes, deletes...)
+
+	for _, addr := range agentOrder(job) {
+		desired, err := desiredResource(job, addr)
+		if err != nil {
+			return nil, err
+		}
+
+		st, tracked := resources[addr]
+		if !tracked {
+			plan.Changes = append(plan.Changes, Change{Addr: addr, Action: ActionCreate, Reason: "not in state"})
+			continue
+		}
+
+		remote, found, err := p.Read(ctx, st.ID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: reading remote object %s: %w", addr, st.ID, err)
+		}
+		if !found {
+			plan.Changes = append(plan.Changes, Change{
+				Addr:   addr,
+				Action: ActionCreate,
+				Reason: fmt.Sprintf("remote object %s missing", st.ID),
+			})
+			plan.Diagnostics = append(plan.Diagnostics, Diagnostic{
+				Severity: SeverityWarning,
+				Addr:     addr,
+				Summary:  "remote object deleted outside adl",
+				Detail:   fmt.Sprintf("state maps %s to %s, but the platform has no such object; apply will recreate it", addr, st.ID),
+			})
+			continue
+		}
+
+		lastApplied, err := decodeConfig(addr, st.Config)
+		if err != nil {
+			return nil, err
+		}
+		drift, err := p.Diff(&Resource{Addr: addr, Config: lastApplied}, remote)
+		if err != nil {
+			return nil, fmt.Errorf("%s: diffing last-applied config: %w", addr, err)
+		}
+		if len(drift) > 0 {
+			plan.Diagnostics = append(plan.Diagnostics, Diagnostic{
+				Severity: SeverityWarning,
+				Addr:     addr,
+				Summary:  "remote object changed outside adl",
+				Detail:   "changed attributes: " + strings.Join(diffPaths(drift), ", "),
+			})
+		}
+
+		diffs, err := p.Diff(desired, remote)
+		if err != nil {
+			return nil, fmt.Errorf("%s: diffing desired config: %w", addr, err)
+		}
+
+		change := Change{Addr: addr, Action: ActionNoop, ID: st.ID, Drift: drift}
+		if len(diffs) > 0 {
+			change.Action = ActionUpdate
+			change.Diffs = diffs
+		}
+		plan.Changes = append(plan.Changes, change)
+	}
+	return plan, nil
+}
+
+// BuildDestroyPlan plans the deletion of every resource the state tracks
+// for the target, in reverse dependency order. It needs no provider —
+// Delete is idempotent, so no remote read can change the outcome.
+func BuildDestroyPlan(job *Job) (*Plan, error) {
+	plan := &Plan{Target: job.Target.Name}
+	resources := stateResources(job)
+
+	addrs := make([]string, 0, len(resources))
+	for addr := range resources {
+		addrs = append(addrs, addr)
+	}
+	for _, addr := range reverseDependencyOrder(addrs, resources) {
+		plan.Changes = append(plan.Changes, Change{
+			Addr:   addr,
+			Action: ActionDelete,
+			ID:     resources[addr].ID,
+			Reason: "destroy",
+		})
+	}
+	return plan, nil
+}
+
+// stateResources returns the tracked resources for the job's target; nil
+// when the target has no state yet. Read-only — BuildPlan must not create
+// state entries as a side effect.
+func stateResources(job *Job) map[string]*state.Resource {
+	ts, ok := job.State.Targets[job.Target.Name]
+	if !ok {
+		return nil
+	}
+	return ts.Resources
+}
+
+// agentOrder filters the module's topological order down to the managed
+// resources (agents).
+func agentOrder(job *Job) []string {
+	var addrs []string
+	for _, addr := range job.Graph.Order() {
+		if strings.HasPrefix(addr, "agent.") {
+			addrs = append(addrs, addr)
+		}
+	}
+	return addrs
+}
+
+// desiredResource renders the desired resource for one agent address.
+func desiredResource(job *Job, addr string) (*Resource, error) {
+	sym, ok := job.Module.Lookup(addr)
+	if !ok {
+		return nil, fmt.Errorf("%s: not declared in module %s", addr, job.Module.Root)
+	}
+	cfg, err := DesiredConfig(job.Module, sym.Block.(*schema.Agent))
+	if err != nil {
+		return nil, err
+	}
+	return &Resource{Addr: addr, Config: cfg}, nil
+}
+
+// removedFromSpec plans deletes for resources tracked in state whose block
+// no longer exists in the module, in reverse dependency order (using the
+// dependencies recorded in state — the module's graph no longer knows these
+// blocks).
+func removedFromSpec(job *Job, resources map[string]*state.Resource) ([]Change, error) {
+	var removed []string
+	for addr := range resources {
+		if _, ok := job.Module.Lookup(addr); !ok {
+			removed = append(removed, addr)
+		}
+	}
+
+	var changes []Change
+	for _, addr := range reverseDependencyOrder(removed, resources) {
+		changes = append(changes, Change{
+			Addr:   addr,
+			Action: ActionDelete,
+			ID:     resources[addr].ID,
+			Reason: "removed from spec",
+		})
+	}
+	return changes, nil
+}
+
+// reverseDependencyOrder orders addrs so that every resource comes before
+// the resources it depends on (reverse topological order over the
+// dependencies recorded in state, restricted to addrs). Ties break
+// lexicographically; dependency cycles cannot occur because the edges were
+// recorded from an acyclic module graph.
+func reverseDependencyOrder(addrs []string, resources map[string]*state.Resource) []string {
+	sort.Strings(addrs)
+	in := map[string]bool{}
+	for _, addr := range addrs {
+		in[addr] = true
+	}
+
+	visited := map[string]bool{}
+	var order []string
+	var visit func(addr string)
+	visit = func(addr string) {
+		visited[addr] = true
+		for _, dep := range resources[addr].Dependencies {
+			if in[dep] && !visited[dep] {
+				visit(dep)
+			}
+		}
+		order = append(order, addr)
+	}
+	for _, addr := range addrs {
+		if !visited[addr] {
+			visit(addr)
+		}
+	}
+
+	for i, j := 0, len(order)-1; i < j; i, j = i+1, j-1 {
+		order[i], order[j] = order[j], order[i]
+	}
+	return order
+}
+
+// decodeConfig parses a resource's last-applied config out of the state
+// file.
+func decodeConfig(addr string, raw json.RawMessage) (Object, error) {
+	var cfg Object
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("%s: state file holds a corrupt last-applied config: %w", addr, err)
+	}
+	return cfg, nil
+}
+
+// diffPaths lists a diff set's attribute paths, sorted.
+func diffPaths(diffs []AttrDiff) []string {
+	paths := make([]string, len(diffs))
+	for i, d := range diffs {
+		paths[i] = d.Path
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// configStale reports whether the canonical desired config differs from the
+// config recorded in state — used by apply to refresh state on noops after
+// the user aligns the spec with a manual remote change.
+func configStale(desired *Resource, recorded json.RawMessage) (bool, error) {
+	want, err := MarshalConfig(desired.Config)
+	if err != nil {
+		return false, err
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, recorded); err != nil {
+		return false, fmt.Errorf("%s: state file holds a corrupt last-applied config: %w", desired.Addr, err)
+	}
+	return !bytes.Equal(want, buf.Bytes()), nil
+}

--- a/internal/provider/plan_test.go
+++ b/internal/provider/plan_test.go
@@ -1,0 +1,394 @@
+package provider_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/graph"
+	"github.com/weirdGuy/agentform/internal/provider"
+	"github.com/weirdGuy/agentform/internal/provider/providertest"
+	"github.com/weirdGuy/agentform/internal/schema"
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// newJob loads the weather fixture and assembles a Job against target.fake
+// with empty state.
+func newJob(t *testing.T) *provider.Job {
+	t.Helper()
+	mod := loadModule(t, "weather")
+	g, err := graph.Build(mod)
+	if err != nil {
+		t.Fatalf("graph.Build: %v", err)
+	}
+	sym, ok := mod.Lookup("target.fake")
+	if !ok {
+		t.Fatal("fixture has no target.fake")
+	}
+	return &provider.Job{
+		Module: mod,
+		Graph:  g,
+		Target: sym.Block.(*schema.Target),
+		State:  &state.File{Version: state.Version, Targets: map[string]*state.TargetState{}},
+	}
+}
+
+// seedAll creates every agent on the fake and records it in state exactly
+// as an apply would have, returning addr → remote id. The fake's call log
+// is reset afterwards so tests assert only their own calls.
+func seedAll(t *testing.T, job *provider.Job, fake *providertest.Fake) map[string]string {
+	t.Helper()
+	ids := map[string]string{}
+	ts := job.State.Target(job.Target.Name)
+	for _, addr := range job.Graph.Order() {
+		if !strings.HasPrefix(addr, "agent.") {
+			continue
+		}
+		sym, _ := job.Module.Lookup(addr)
+		cfg, err := provider.DesiredConfig(job.Module, sym.Block.(*schema.Agent))
+		if err != nil {
+			t.Fatalf("DesiredConfig(%s): %v", addr, err)
+		}
+		id, err := fake.Create(context.Background(), &provider.Resource{Addr: addr, Config: cfg})
+		if err != nil {
+			t.Fatalf("seeding %s: %v", addr, err)
+		}
+		raw, err := provider.MarshalConfig(cfg)
+		if err != nil {
+			t.Fatalf("MarshalConfig(%s): %v", addr, err)
+		}
+		var deps []string
+		for _, dep := range job.Graph.Dependencies(addr) {
+			if strings.HasPrefix(dep, "agent.") {
+				deps = append(deps, dep)
+			}
+		}
+		ts.Resources[addr] = &state.Resource{ID: id, Config: raw, Dependencies: deps}
+		ids[addr] = id
+	}
+	fake.Calls = nil
+	return ids
+}
+
+// changeSummary flattens a plan to "action addr" lines for order assertions.
+func changeSummary(p *provider.Plan) []string {
+	var out []string
+	for _, c := range p.Changes {
+		out = append(out, string(c.Action)+" "+c.Addr)
+	}
+	return out
+}
+
+func TestBuildPlanFreshModuleCreatesInTopoOrder(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{"create agent.geocoder", "create agent.forecast", "create agent.weather"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	for _, c := range plan.Changes {
+		if c.Reason != "not in state" {
+			t.Errorf("%s: Reason = %q, want %q", c.Addr, c.Reason, "not in state")
+		}
+		if c.ID != "" {
+			t.Errorf("%s: create has ID %q, want empty", c.Addr, c.ID)
+		}
+	}
+	if len(plan.Diagnostics) != 0 {
+		t.Errorf("unexpected diagnostics: %+v", plan.Diagnostics)
+	}
+	if len(fake.Calls) != 0 {
+		t.Errorf("plan against empty state made provider calls: %v", fake.Calls)
+	}
+}
+
+func TestBuildPlanInSyncIsAllNoops(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	ids := seedAll(t, job, fake)
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{"noop agent.geocoder", "noop agent.forecast", "noop agent.weather"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	for _, c := range plan.Changes {
+		if c.ID != ids[c.Addr] {
+			t.Errorf("%s: ID = %q, want %q", c.Addr, c.ID, ids[c.Addr])
+		}
+	}
+	if len(plan.Diagnostics) != 0 {
+		t.Errorf("unexpected diagnostics: %+v", plan.Diagnostics)
+	}
+
+	// Plan is a pure read: only Read and Diff calls are allowed.
+	for _, call := range fake.Calls {
+		if !strings.HasPrefix(call, "read ") && !strings.HasPrefix(call, "diff ") {
+			t.Errorf("plan issued mutating call %q", call)
+		}
+	}
+}
+
+func TestBuildPlanSpecChangeIsAnUpdate(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	ids := seedAll(t, job, fake)
+
+	// Simulate an older applied config: remote and state both carry the
+	// previous model id, the spec now says gpt-4o-mini.
+	stale := fake.Objects[ids["agent.geocoder"]]
+	stale["model"].(map[string]any)["id"] = "gpt-4o"
+	ts := job.State.Target("fake")
+	raw, _ := provider.MarshalConfig(stale)
+	ts.Resources["agent.geocoder"].Config = raw
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{"update agent.geocoder", "noop agent.forecast", "noop agent.weather"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	upd := plan.Changes[0]
+	wantDiffs := []provider.AttrDiff{{Path: "model.id", Old: "gpt-4o", New: "gpt-4o-mini"}}
+	if diff := cmp.Diff(wantDiffs, upd.Diffs); diff != "" {
+		t.Errorf("update diffs (-want +got):\n%s", diff)
+	}
+	// Remote still matches what was last applied — no drift.
+	if len(upd.Drift) != 0 || len(plan.Diagnostics) != 0 {
+		t.Errorf("unexpected drift: %+v diagnostics: %+v", upd.Drift, plan.Diagnostics)
+	}
+}
+
+func TestBuildPlanRemovedFromSpecDeletesInReverseDependencyOrder(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+
+	// Two resources tracked in state but no longer in the spec;
+	// legacy_b depends on legacy_a, so b must be deleted first.
+	ts := job.State.Target("fake")
+	ts.Resources["agent.legacy_a"] = &state.Resource{ID: "fake-90", Config: json.RawMessage(`{}`)}
+	ts.Resources["agent.legacy_b"] = &state.Resource{ID: "fake-91", Config: json.RawMessage(`{}`), Dependencies: []string{"agent.legacy_a"}}
+	fake.Objects["fake-90"] = provider.Object{}
+	fake.Objects["fake-91"] = provider.Object{}
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{
+		"delete agent.legacy_b", "delete agent.legacy_a",
+		"noop agent.geocoder", "noop agent.forecast", "noop agent.weather",
+	}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	for _, c := range plan.Changes[:2] {
+		if c.Reason != "removed from spec" {
+			t.Errorf("%s: Reason = %q, want %q", c.Addr, c.Reason, "removed from spec")
+		}
+	}
+}
+
+func TestBuildPlanRemoteDeletedOutsideAdl(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	ids := seedAll(t, job, fake)
+	delete(fake.Objects, ids["agent.forecast"])
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{"noop agent.geocoder", "create agent.forecast", "noop agent.weather"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	create := plan.Changes[1]
+	if !strings.Contains(create.Reason, ids["agent.forecast"]) || !strings.Contains(create.Reason, "missing") {
+		t.Errorf("Reason = %q, want mention of missing remote %s", create.Reason, ids["agent.forecast"])
+	}
+
+	if len(plan.Diagnostics) != 1 {
+		t.Fatalf("diagnostics = %+v, want exactly one drift warning", plan.Diagnostics)
+	}
+	d := plan.Diagnostics[0]
+	if d.Severity != provider.SeverityWarning || d.Addr != "agent.forecast" {
+		t.Errorf("diagnostic = %+v, want warning for agent.forecast", d)
+	}
+	if !strings.Contains(d.Summary, "deleted outside adl") {
+		t.Errorf("Summary = %q, want mention of out-of-band deletion", d.Summary)
+	}
+}
+
+func TestBuildPlanRemoteDriftConvergesBackWithWarning(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	ids := seedAll(t, job, fake)
+
+	// Someone edited the remote object out-of-band; the spec did not change.
+	fake.Objects[ids["agent.weather"]]["instructions"] = "hacked"
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{"noop agent.geocoder", "noop agent.forecast", "update agent.weather"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	upd := plan.Changes[2]
+	if len(upd.Diffs) != 1 || upd.Diffs[0].Path != "instructions" {
+		t.Errorf("Diffs = %+v, want one diff on instructions", upd.Diffs)
+	}
+	if len(upd.Drift) != 1 || upd.Drift[0].Path != "instructions" {
+		t.Errorf("Drift = %+v, want one drift on instructions", upd.Drift)
+	}
+
+	if len(plan.Diagnostics) != 1 {
+		t.Fatalf("diagnostics = %+v, want exactly one drift warning", plan.Diagnostics)
+	}
+	d := plan.Diagnostics[0]
+	if d.Severity != provider.SeverityWarning || d.Addr != "agent.weather" {
+		t.Errorf("diagnostic = %+v, want warning for agent.weather", d)
+	}
+	if !strings.Contains(d.Summary, "changed outside adl") || !strings.Contains(d.Detail, "instructions") {
+		t.Errorf("diagnostic %+v does not name the drifted attribute", d)
+	}
+}
+
+func TestBuildPlanSpecAlignedWithManualChangeIsNoopWithDrift(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+
+	// The remote matches the spec, but state recorded an older config: the
+	// user edited the spec to match a manual remote change. No update is
+	// needed; the drift is still reported and apply will refresh state.
+	ts := job.State.Target("fake")
+	var cfg provider.Object
+	if err := json.Unmarshal(ts.Resources["agent.geocoder"].Config, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfg["model"].(map[string]any)["id"] = "gpt-4o"
+	raw, _ := provider.MarshalConfig(cfg)
+	ts.Resources["agent.geocoder"].Config = raw
+
+	plan, err := provider.BuildPlan(context.Background(), fake, job)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	want := []string{"noop agent.geocoder", "noop agent.forecast", "noop agent.weather"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	if len(plan.Changes[0].Drift) != 1 || plan.Changes[0].Drift[0].Path != "model.id" {
+		t.Errorf("Drift = %+v, want one drift on model.id", plan.Changes[0].Drift)
+	}
+	if len(plan.Diagnostics) != 1 || plan.Diagnostics[0].Severity != provider.SeverityWarning {
+		t.Errorf("diagnostics = %+v, want one warning", plan.Diagnostics)
+	}
+}
+
+func TestBuildPlanReadErrorNamesTheResource(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	ids := seedAll(t, job, fake)
+	boom := errors.New("rate limited")
+	fake.FailOn = map[string]error{"read " + ids["agent.forecast"]: boom}
+
+	_, err := provider.BuildPlan(context.Background(), fake, job)
+	if err == nil {
+		t.Fatal("BuildPlan succeeded, want error")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error %v does not wrap the provider error", err)
+	}
+	for _, want := range []string{"agent.forecast", ids["agent.forecast"]} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestBuildPlanCorruptStateConfigFails(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+	job.State.Target("fake").Resources["agent.geocoder"].Config = json.RawMessage(`{broken`)
+
+	_, err := provider.BuildPlan(context.Background(), fake, job)
+	if err == nil {
+		t.Fatal("BuildPlan succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "agent.geocoder") {
+		t.Errorf("error %q does not name the resource", err)
+	}
+}
+
+func TestPlanCounts(t *testing.T) {
+	p := &provider.Plan{Changes: []provider.Change{
+		{Action: provider.ActionCreate}, {Action: provider.ActionCreate},
+		{Action: provider.ActionUpdate},
+		{Action: provider.ActionDelete},
+		{Action: provider.ActionNoop}, {Action: provider.ActionNoop}, {Action: provider.ActionNoop},
+	}}
+	create, update, del, noop := p.Counts()
+	if create != 2 || update != 1 || del != 1 || noop != 3 {
+		t.Errorf("Counts() = %d,%d,%d,%d; want 2,1,1,3", create, update, del, noop)
+	}
+}
+
+func TestBuildDestroyPlanDeletesEverythingReverseOrder(t *testing.T) {
+	job := newJob(t)
+	fake := providertest.New()
+	seedAll(t, job, fake)
+	fake.Calls = nil
+
+	plan, err := provider.BuildDestroyPlan(job)
+	if err != nil {
+		t.Fatalf("BuildDestroyPlan: %v", err)
+	}
+
+	// Reverse dependency order: weather and forecast depend on geocoder
+	// (weather also on forecast), so geocoder goes last.
+	want := []string{"delete agent.weather", "delete agent.forecast", "delete agent.geocoder"}
+	if diff := cmp.Diff(want, changeSummary(plan)); diff != "" {
+		t.Errorf("changes (-want +got):\n%s", diff)
+	}
+	if len(fake.Calls) != 0 {
+		t.Errorf("destroy plan made provider calls: %v", fake.Calls)
+	}
+}
+
+func TestBuildDestroyPlanEmptyState(t *testing.T) {
+	job := newJob(t)
+	plan, err := provider.BuildDestroyPlan(job)
+	if err != nil {
+		t.Fatalf("BuildDestroyPlan: %v", err)
+	}
+	if len(plan.Changes) != 0 {
+		t.Errorf("changes = %+v, want none", plan.Changes)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,59 @@
+// Package provider is the target-agnostic plan/apply engine (SPEC.md §6):
+// it renders a loaded module into desired resource configurations, compares
+// them three ways (spec vs. state vs. remote) into a plan, and executes
+// plans against a platform through the Provider contract. Per-platform
+// reconcilers live in subpackages (provider/openai, ...) and implement
+// Provider; nothing platform-specific appears in this package.
+//
+// The contract deliberately traffics only in serializable, provider-neutral
+// values (block addresses, JSON value trees) so it can move behind a plugin
+// boundary later without redesign.
+package provider
+
+import "context"
+
+// Object is a JSON value tree using the encoding/json value model: every
+// value is a string, float64, bool, nil, []any, or map[string]any. Desired
+// configs, last-applied configs, and remote reads all use this model, so
+// comparisons never trip over Go-side type differences.
+type Object = map[string]any
+
+// Resource is one managed resource: a block address plus its desired
+// configuration. In v0 every agent block is one resource — models, prompts,
+// and tools are folded into the agent's config (see DesiredConfig).
+type Resource struct {
+	Addr   string `json:"addr"`
+	Config Object `json:"config"`
+}
+
+// AttrDiff is one attribute-level difference between a desired config and
+// a remote object, at a dotted path like "model.id" or "tools[0].source.uri".
+type AttrDiff struct {
+	Path string `json:"path"`
+	Old  any    `json:"old"` // nil when the attribute is being added
+	New  any    `json:"new"` // nil when the attribute is being removed
+}
+
+// Provider is the contract every platform reconciler implements
+// (SPEC.md §6). The engine holds providers to these rules:
+//
+//   - Read reports found=false for a resource deleted outside adl; that is
+//     data (drift), not an error.
+//   - Create returns the platform's identifier for the new resource; the
+//     engine records it in state immediately.
+//   - Delete is idempotent: deleting an id that no longer exists remotely
+//     succeeds, so a re-run after a partial failure converges.
+//   - Diff is the comparison authority — only the provider knows how a
+//     desired config maps onto its platform's attributes. An empty result
+//     means "in sync". The engine calls it with the spec's desired config
+//     (update-or-noop decision) and with the last-applied config from state
+//     (drift detection).
+//   - Diff must be pure and deterministic; Read must not mutate anything.
+//     adl plan issues only Read and Diff calls.
+type Provider interface {
+	Read(ctx context.Context, id string) (remote Object, found bool, err error)
+	Create(ctx context.Context, desired *Resource) (id string, err error)
+	Update(ctx context.Context, id string, desired *Resource) error
+	Delete(ctx context.Context, id string) error
+	Diff(desired *Resource, remote Object) ([]AttrDiff, error)
+}

--- a/internal/provider/providertest/providertest.go
+++ b/internal/provider/providertest/providertest.go
@@ -1,0 +1,176 @@
+// Package providertest provides an in-memory Provider for testing the
+// plan/apply engine and CLI without a real platform (mirroring buildtest
+// for the codegen engine). Its remote objects are stored verbatim as the
+// desired configs that created them, so its Diff is a generic structural
+// comparison over the JSON value model.
+package providertest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/weirdGuy/agentform/internal/provider"
+)
+
+// Fake is an in-memory provider.Provider. Zero-configuration tests just
+// call New; failure injection and drift simulation work by mutating FailOn
+// and Objects directly.
+type Fake struct {
+	// Objects maps remote id → stored object (a deep copy of the config
+	// that created or last updated it). Tests mutate entries to simulate
+	// drift and delete entries to simulate out-of-band deletion.
+	Objects map[string]provider.Object
+	// Calls records every call in order, formatted like "create agent.a",
+	// "read fake-1", "diff agent.a" — create/update/diff key on the block
+	// address, read/delete on the remote id.
+	Calls []string
+	// FailOn maps a Calls entry to the error that call should return.
+	FailOn map[string]error
+
+	nextID int
+}
+
+// New returns an empty Fake. Remote ids are assigned as fake-1, fake-2, …
+// in creation order.
+func New() *Fake {
+	return &Fake{Objects: map[string]provider.Object{}}
+}
+
+// call logs one provider call and returns its injected failure, if any.
+func (f *Fake) call(op, key string) error {
+	entry := op + " " + key
+	f.Calls = append(f.Calls, entry)
+	return f.FailOn[entry]
+}
+
+// Read implements provider.Provider.
+func (f *Fake) Read(_ context.Context, id string) (provider.Object, bool, error) {
+	if err := f.call("read", id); err != nil {
+		return nil, false, err
+	}
+	obj, ok := f.Objects[id]
+	if !ok {
+		return nil, false, nil
+	}
+	return deepCopy(obj), true, nil
+}
+
+// Create implements provider.Provider.
+func (f *Fake) Create(_ context.Context, desired *provider.Resource) (string, error) {
+	if err := f.call("create", desired.Addr); err != nil {
+		return "", err
+	}
+	f.nextID++
+	id := fmt.Sprintf("fake-%d", f.nextID)
+	f.Objects[id] = deepCopy(desired.Config)
+	return id, nil
+}
+
+// Update implements provider.Provider.
+func (f *Fake) Update(_ context.Context, id string, desired *provider.Resource) error {
+	if err := f.call("update", desired.Addr); err != nil {
+		return err
+	}
+	if _, ok := f.Objects[id]; !ok {
+		return fmt.Errorf("no remote object %s", id)
+	}
+	f.Objects[id] = deepCopy(desired.Config)
+	return nil
+}
+
+// Delete implements provider.Provider. Deleting a missing id succeeds, as
+// the contract requires.
+func (f *Fake) Delete(_ context.Context, id string) error {
+	if err := f.call("delete", id); err != nil {
+		return err
+	}
+	delete(f.Objects, id)
+	return nil
+}
+
+// Diff implements provider.Provider with a generic structural comparison:
+// maps diff by sorted key union, same-length arrays element-wise, anything
+// else as a leaf. Old is the remote value, New the desired one.
+func (f *Fake) Diff(desired *provider.Resource, remote provider.Object) ([]provider.AttrDiff, error) {
+	if err := f.call("diff", desired.Addr); err != nil {
+		return nil, err
+	}
+	var diffs []provider.AttrDiff
+	diffValue("", desired.Config, remote, &diffs)
+	return diffs, nil
+}
+
+// diffValue appends the differences between desired and remote at path.
+func diffValue(path string, desired, remote any, out *[]provider.AttrDiff) {
+	switch d := desired.(type) {
+	case map[string]any:
+		r, ok := remote.(map[string]any)
+		if !ok {
+			appendLeaf(path, desired, remote, out)
+			return
+		}
+		keys := map[string]bool{}
+		for k := range d {
+			keys[k] = true
+		}
+		for k := range r {
+			keys[k] = true
+		}
+		sorted := make([]string, 0, len(keys))
+		for k := range keys {
+			sorted = append(sorted, k)
+		}
+		sort.Strings(sorted)
+		for _, k := range sorted {
+			dv, inD := d[k]
+			rv, inR := r[k]
+			sub := k
+			if path != "" {
+				sub = path + "." + k
+			}
+			switch {
+			case !inR:
+				*out = append(*out, provider.AttrDiff{Path: sub, Old: nil, New: dv})
+			case !inD:
+				*out = append(*out, provider.AttrDiff{Path: sub, Old: rv, New: nil})
+			default:
+				diffValue(sub, dv, rv, out)
+			}
+		}
+	case []any:
+		r, ok := remote.([]any)
+		if !ok || len(r) != len(d) {
+			appendLeaf(path, desired, remote, out)
+			return
+		}
+		for i := range d {
+			diffValue(fmt.Sprintf("%s[%d]", path, i), d[i], r[i], out)
+		}
+	default:
+		appendLeaf(path, desired, remote, out)
+	}
+}
+
+// appendLeaf records a leaf-level difference, if there is one.
+func appendLeaf(path string, desired, remote any, out *[]provider.AttrDiff) {
+	if !reflect.DeepEqual(desired, remote) {
+		*out = append(*out, provider.AttrDiff{Path: path, Old: remote, New: desired})
+	}
+}
+
+// deepCopy clones a JSON value tree so the fake's store never shares
+// structure with callers.
+func deepCopy(obj provider.Object) provider.Object {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(fmt.Sprintf("providertest: object is not a JSON value tree: %v", err))
+	}
+	var out provider.Object
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(fmt.Sprintf("providertest: %v", err))
+	}
+	return out
+}

--- a/internal/provider/providertest/providertest_test.go
+++ b/internal/provider/providertest/providertest_test.go
@@ -1,0 +1,169 @@
+package providertest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/provider"
+	"github.com/weirdGuy/agentform/internal/provider/providertest"
+)
+
+func TestFakeDiff(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired provider.Object
+		remote  provider.Object
+		want    []provider.AttrDiff
+	}{
+		{
+			name:    "equal configs produce no diffs",
+			desired: provider.Object{"a": "x", "n": 1.0},
+			remote:  provider.Object{"a": "x", "n": 1.0},
+			want:    nil,
+		},
+		{
+			name:    "changed leaf reports remote as old, desired as new",
+			desired: provider.Object{"model": map[string]any{"id": "gpt-4o-mini"}},
+			remote:  provider.Object{"model": map[string]any{"id": "gpt-4o"}},
+			want:    []provider.AttrDiff{{Path: "model.id", Old: "gpt-4o", New: "gpt-4o-mini"}},
+		},
+		{
+			name:    "attribute only in desired is an add",
+			desired: provider.Object{"description": "new"},
+			remote:  provider.Object{},
+			want:    []provider.AttrDiff{{Path: "description", Old: nil, New: "new"}},
+		},
+		{
+			name:    "attribute only in remote is a removal",
+			desired: provider.Object{},
+			remote:  provider.Object{"description": "gone"},
+			want:    []provider.AttrDiff{{Path: "description", Old: "gone", New: nil}},
+		},
+		{
+			name:    "same-length arrays diff element-wise",
+			desired: provider.Object{"tools": []any{map[string]any{"name": "a"}, map[string]any{"name": "b"}}},
+			remote:  provider.Object{"tools": []any{map[string]any{"name": "a"}, map[string]any{"name": "c"}}},
+			want:    []provider.AttrDiff{{Path: "tools[1].name", Old: "c", New: "b"}},
+		},
+		{
+			name:    "different-length arrays diff as a whole",
+			desired: provider.Object{"tags": []any{"a"}},
+			remote:  provider.Object{"tags": []any{"a", "b"}},
+			want:    []provider.AttrDiff{{Path: "tags", Old: []any{"a", "b"}, New: []any{"a"}}},
+		},
+		{
+			name:    "multiple diffs come out in sorted key order",
+			desired: provider.Object{"b": "2", "a": "1"},
+			remote:  provider.Object{"b": "x", "a": "y"},
+			want: []provider.AttrDiff{
+				{Path: "a", Old: "y", New: "1"},
+				{Path: "b", Old: "x", New: "2"},
+			},
+		},
+	}
+
+	fake := providertest.New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fake.Diff(&provider.Resource{Addr: "agent.x", Config: tt.desired}, tt.remote)
+			if err != nil {
+				t.Fatalf("Diff: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Diff() (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFakeLifecycle(t *testing.T) {
+	ctx := context.Background()
+	fake := providertest.New()
+
+	id1, err := fake.Create(ctx, &provider.Resource{Addr: "agent.a", Config: provider.Object{"v": "1"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id2, err := fake.Create(ctx, &provider.Resource{Addr: "agent.b", Config: provider.Object{"v": "2"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id1 != "fake-1" || id2 != "fake-2" {
+		t.Errorf("ids = %s, %s; want fake-1, fake-2", id1, id2)
+	}
+
+	remote, found, err := fake.Read(ctx, id1)
+	if err != nil || !found {
+		t.Fatalf("Read(%s) = found %v, err %v", id1, found, err)
+	}
+	// Read hands out a copy: mutating it must not corrupt the store.
+	remote["v"] = "mutated"
+	again, _, _ := fake.Read(ctx, id1)
+	if again["v"] != "1" {
+		t.Error("Read returned a live reference into the fake's store")
+	}
+
+	if err := fake.Update(ctx, id1, &provider.Resource{Addr: "agent.a", Config: provider.Object{"v": "3"}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	updated, _, _ := fake.Read(ctx, id1)
+	if updated["v"] != "3" {
+		t.Errorf("after Update, v = %v, want 3", updated["v"])
+	}
+
+	if err := fake.Delete(ctx, id1); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, found, _ := fake.Read(ctx, id1); found {
+		t.Error("object still found after Delete")
+	}
+	// Delete is idempotent by contract.
+	if err := fake.Delete(ctx, id1); err != nil {
+		t.Errorf("second Delete errored: %v", err)
+	}
+
+	wantCalls := []string{
+		"create agent.a", "create agent.b",
+		"read fake-1", "read fake-1",
+		"update agent.a", "read fake-1",
+		"delete fake-1", "read fake-1", "delete fake-1",
+	}
+	if diff := cmp.Diff(wantCalls, fake.Calls); diff != "" {
+		t.Errorf("Calls (-want +got):\n%s", diff)
+	}
+}
+
+func TestFakeFailOn(t *testing.T) {
+	ctx := context.Background()
+	fake := providertest.New()
+	boom := errors.New("boom")
+	fake.FailOn = map[string]error{"create agent.b": boom}
+
+	if _, err := fake.Create(ctx, &provider.Resource{Addr: "agent.a", Config: provider.Object{}}); err != nil {
+		t.Fatalf("Create(agent.a): %v", err)
+	}
+	if _, err := fake.Create(ctx, &provider.Resource{Addr: "agent.b", Config: provider.Object{}}); !errors.Is(err, boom) {
+		t.Errorf("Create(agent.b) error = %v, want boom", err)
+	}
+
+	fake.FailOn = map[string]error{"update agent.a": boom}
+	if err := fake.Update(ctx, "fake-1", &provider.Resource{Addr: "agent.a", Config: provider.Object{}}); !errors.Is(err, boom) {
+		t.Errorf("Update error = %v, want boom", err)
+	}
+
+	fake.FailOn = map[string]error{"read fake-1": boom}
+	if _, _, err := fake.Read(ctx, "fake-1"); !errors.Is(err, boom) {
+		t.Errorf("Read error = %v, want boom", err)
+	}
+}
+
+func TestFakeUpdateUnknownIDFails(t *testing.T) {
+	fake := providertest.New()
+	err := fake.Update(context.Background(), "fake-404", &provider.Resource{Addr: "agent.a", Config: provider.Object{}})
+	if err == nil {
+		t.Fatal("Update of unknown id succeeded, want error")
+	}
+}

--- a/internal/provider/testdata/weather/adl.hcl
+++ b/internal/provider/testdata/weather/adl.hcl
@@ -1,0 +1,12 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+  params {
+    temperature = 0.2
+    max_tokens  = 4096
+  }
+}
+
+target "fake" {
+  type = "platform"
+}

--- a/internal/provider/testdata/weather/agents.agent
+++ b/internal/provider/testdata/weather/agents.agent
@@ -1,0 +1,53 @@
+agent "geocoder" {
+  model = model.fast
+
+  input "place" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}
+
+agent "forecast" {
+  model = model.fast
+
+  input "coordinates" {
+    type    = string
+    default = agent.geocoder.output.coordinates
+  }
+
+  output "summary" {
+    type = string
+  }
+}
+
+agent "weather" {
+  description   = "Answers weather questions"
+  model         = model.fast
+  system_prompt = prompt.weather_system
+
+  tools = [tool.web_search]
+
+  input "location" {
+    type        = string
+    description = "The location to get the weather for"
+  }
+
+  input "date" {
+    type     = string
+    optional = true
+  }
+
+  input "forecast_context" {
+    type    = string
+    default = agent.forecast.output.summary
+  }
+
+  output "report" {
+    type = string
+  }
+
+  depends_on = [agent.geocoder]
+}

--- a/internal/provider/testdata/weather/tools.tool
+++ b/internal/provider/testdata/weather/tools.tool
@@ -1,0 +1,22 @@
+tool "web_search" {
+  description = "Search the web"
+
+  param "query" {
+    type        = string
+    description = "The query to search for"
+  }
+
+  param "max_results" {
+    type    = number
+    default = 10
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "mcp"
+    uri  = "mcp://search-server/web_search"
+  }
+}

--- a/internal/provider/testdata/weather/weather.prompt
+++ b/internal/provider/testdata/weather/weather.prompt
@@ -1,0 +1,5 @@
+---
+name = "weather_system"
+requires = ["location"]
+---
+You are a weather assistant for {{location}}.

--- a/internal/state/lock.go
+++ b/internal/state/lock.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// LockFilename is the local lock file guarding the state file. It is
+// hidden so the module walker never treats it as module input. Remote
+// state backends (and their locking) are deferred per SPEC.md §7.
+const LockFilename = ".adl.state.lock"
+
+// lockInfo is the lock file payload — purely informational, for the
+// contention error message.
+type lockInfo struct {
+	PID     int    `json:"pid"`
+	Created string `json:"created"`
+}
+
+// Lock takes the state lock for the module rooted at dir by creating the
+// lock file exclusively. It returns a release function that removes the
+// file. If another process holds the lock, the error says who and how to
+// recover; a crashed process leaves a stale lock that must be deleted by
+// hand in v0.
+func Lock(dir string) (release func() error, err error) {
+	path := filepath.Join(dir, LockFilename)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if errors.Is(err, fs.ErrExist) {
+		return nil, contentionError(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("locking state: %w", err)
+	}
+
+	info := lockInfo{PID: os.Getpid(), Created: time.Now().UTC().Format(time.RFC3339)}
+	data, _ := json.Marshal(info)
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		f.Close()
+		os.Remove(path)
+		return nil, fmt.Errorf("locking state: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return nil, fmt.Errorf("locking state: %w", err)
+	}
+
+	return func() error {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("releasing state lock: %w", err)
+		}
+		return nil
+	}, nil
+}
+
+// contentionError describes an already-held lock, including the holder
+// recorded in the lock file when it is readable.
+func contentionError(path string) error {
+	holder := ""
+	if data, err := os.ReadFile(path); err == nil {
+		var info lockInfo
+		if json.Unmarshal(data, &info) == nil && info.PID != 0 {
+			holder = fmt.Sprintf(" (held by pid %d since %s)", info.PID, info.Created)
+		}
+	}
+	return fmt.Errorf("state is locked by another adl process%s: if that process is no longer running, delete %s", holder, path)
+}

--- a/internal/state/lock_test.go
+++ b/internal/state/lock_test.go
@@ -1,0 +1,78 @@
+package state_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+func TestLockAcquireReleaseReacquire(t *testing.T) {
+	dir := t.TempDir()
+
+	release, err := state.Lock(dir)
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, state.LockFilename)); err != nil {
+		t.Fatalf("lock file not created: %v", err)
+	}
+
+	if err := release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, state.LockFilename)); !os.IsNotExist(err) {
+		t.Fatal("lock file still exists after release")
+	}
+
+	release, err = state.Lock(dir)
+	if err != nil {
+		t.Fatalf("Lock after release: %v", err)
+	}
+	defer release()
+}
+
+func TestLockContention(t *testing.T) {
+	dir := t.TempDir()
+
+	release, err := state.Lock(dir)
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	defer release()
+
+	_, err = state.Lock(dir)
+	if err == nil {
+		t.Fatal("second Lock succeeded, want contention error")
+	}
+	// The error must say who holds the lock and how to recover.
+	for _, want := range []string{
+		state.LockFilename,
+		"pid " + strconv.Itoa(os.Getpid()),
+		"delete",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("contention error %q missing substring %q", err, want)
+		}
+	}
+}
+
+func TestLockContentionWithUnreadableLockFile(t *testing.T) {
+	dir := t.TempDir()
+	// A lock file left by something else entirely still blocks, without
+	// crashing on the unparsable payload.
+	if err := os.WriteFile(filepath.Join(dir, state.LockFilename), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := state.Lock(dir)
+	if err == nil {
+		t.Fatal("Lock succeeded despite existing lock file")
+	}
+	if !strings.Contains(err.Error(), state.LockFilename) {
+		t.Errorf("error %q does not name the lock file", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,122 @@
+// Package state owns the adl.state.json file (SPEC.md §5): the record of
+// which remote resource each block address maps to and the configuration
+// last applied to it, used by adl plan/apply for three-way comparison and
+// drift detection.
+//
+// Determinism guarantee: writing equal logical state always produces
+// byte-identical files — struct fields serialize in declared order, maps in
+// sorted key order, and configs are stored as canonical JSON produced by
+// the provider engine.
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Version is the state file format version this adl reads and writes.
+// Load rejects any other version rather than misinterpreting it (the same
+// stance SPEC.md §9 takes on language versioning).
+const Version = 1
+
+// Filename is the state file's name, fixed at the module root.
+const Filename = "adl.state.json"
+
+// File is the decoded state file. Serial increases by one on every Write,
+// so any two snapshots of the same module's state are ordered.
+type File struct {
+	Version int                     `json:"version"`
+	Serial  uint64                  `json:"serial"`
+	Targets map[string]*TargetState `json:"targets"`
+}
+
+// TargetState is the managed resource set of one platform target.
+type TargetState struct {
+	Resources map[string]*Resource `json:"resources"`
+}
+
+// Resource records one managed remote resource: the remote ID it maps to,
+// the canonical JSON of the configuration last applied to it (full config,
+// not a hash — drift reports name the attributes that changed), and its
+// managed dependencies (block addresses), kept so a resource removed from
+// the spec can still be destroyed in reverse dependency order.
+type Resource struct {
+	ID           string          `json:"id"`
+	Config       json.RawMessage `json:"config"`
+	Dependencies []string        `json:"dependencies,omitempty"`
+}
+
+// Load reads the state file at the root of dir. A missing file is an empty
+// state, not an error — every module starts unmanaged.
+func Load(dir string) (*File, error) {
+	path := filepath.Join(dir, Filename)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &File{Version: Version, Targets: map[string]*TargetState{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading state file: %w", err)
+	}
+
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("%s: parsing state file: %w", path, err)
+	}
+	if f.Version != Version {
+		return nil, fmt.Errorf("%s: state file version %d is not supported by this adl (supports version %d)", path, f.Version, Version)
+	}
+	if f.Targets == nil {
+		f.Targets = map[string]*TargetState{}
+	}
+	return &f, nil
+}
+
+// Write bumps the serial and atomically replaces the state file at the root
+// of dir (temp file + rename, so a crash never leaves a torn file). Targets
+// with no resources are dropped from the output — an empty entry carries no
+// information and would accumulate forever.
+func (f *File) Write(dir string) error {
+	f.Version = Version
+	f.Serial++
+
+	out := &File{Version: f.Version, Serial: f.Serial, Targets: map[string]*TargetState{}}
+	for name, ts := range f.Targets {
+		if len(ts.Resources) > 0 {
+			out.Targets[name] = ts
+		}
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding state file: %w", err)
+	}
+	data = append(data, '\n')
+
+	path := filepath.Join(dir, Filename)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
+	}
+	return nil
+}
+
+// Target returns the state of one platform target, creating an empty entry
+// if the target is not tracked yet.
+func (f *File) Target(name string) *TargetState {
+	if ts, ok := f.Targets[name]; ok {
+		if ts.Resources == nil {
+			ts.Resources = map[string]*Resource{}
+		}
+		return ts
+	}
+	ts := &TargetState{Resources: map[string]*Resource{}}
+	f.Targets[name] = ts
+	return ts
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,201 @@
+package state_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/agentform/internal/state"
+)
+
+// sample returns a populated state file exercising every schema field:
+// multiple targets, multiple resources, dependencies present and absent.
+func sample() *state.File {
+	return &state.File{
+		Version: state.Version,
+		Serial:  6,
+		Targets: map[string]*state.TargetState{
+			"openai_assistants": {
+				Resources: map[string]*state.Resource{
+					"agent.weather": {
+						ID:           "asst_123",
+						Config:       json.RawMessage(`{"description":"Answers weather questions","model":{"id":"gpt-4o-mini","provider":"openai"}}`),
+						Dependencies: []string{"agent.geocoder"},
+					},
+					"agent.geocoder": {
+						ID:     "asst_456",
+						Config: json.RawMessage(`{"model":{"id":"gpt-4o-mini","provider":"openai"}}`),
+					},
+				},
+			},
+			"empty_platform": {Resources: map[string]*state.Resource{}},
+		},
+	}
+}
+
+func TestLoadMissingFileIsEmptyState(t *testing.T) {
+	f, err := state.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	want := &state.File{Version: state.Version, Targets: map[string]*state.TargetState{}}
+	if diff := cmp.Diff(want, f); diff != "" {
+		t.Errorf("Load() (-want +got):\n%s", diff)
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		wantSub []string // substrings the error must contain
+	}{
+		{
+			name:    "corrupt JSON names the file",
+			dir:     "testdata/corrupt",
+			wantSub: []string{state.Filename, "parsing state file"},
+		},
+		{
+			name:    "future version is rejected, naming found and supported",
+			dir:     "testdata/future_version",
+			wantSub: []string{state.Filename, "version 3", "supports version 1"},
+		},
+		{
+			name:    "missing version is rejected",
+			dir:     "testdata/version_missing",
+			wantSub: []string{state.Filename, "version 0", "supports version 1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := state.Load(tt.dir)
+			if err == nil {
+				t.Fatal("Load succeeded, want error")
+			}
+			for _, want := range tt.wantSub {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q missing substring %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	f := sample()
+	if err := f.Write(dir); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	want := sample()
+	want.Serial = 7                        // Write bumps the serial
+	delete(want.Targets, "empty_platform") // Write drops empty targets
+	if diff := cmp.Diff(want, got, cmp.Transformer("compact", compactJSON)); diff != "" {
+		t.Errorf("round trip (-want +got):\n%s", diff)
+	}
+}
+
+// compactJSON normalizes raw config whitespace so round-trip comparison is
+// about content, not indentation.
+func compactJSON(raw json.RawMessage) string {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return string(raw)
+	}
+	return string(out)
+}
+
+func TestWriteIsDeterministic(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	if err := sample().Write(a); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := sample().Write(b); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	bytesA := readState(t, a)
+	bytesB := readState(t, b)
+	if string(bytesA) != string(bytesB) {
+		t.Errorf("two writes of equal state differ:\n%s\nvs:\n%s", bytesA, bytesB)
+	}
+}
+
+func TestWriteGolden(t *testing.T) {
+	dir := t.TempDir()
+	if err := sample().Write(dir); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := readState(t, dir)
+
+	want, err := os.ReadFile(filepath.Join("testdata", "golden.state.json"))
+	if err != nil {
+		t.Fatalf("reading golden file: %v", err)
+	}
+	if diff := cmp.Diff(string(want), string(got)); diff != "" {
+		t.Errorf("state bytes (-want +got):\n%s", diff)
+	}
+}
+
+func TestWriteEndsWithNewline(t *testing.T) {
+	dir := t.TempDir()
+	if err := sample().Write(dir); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := readState(t, dir)
+	if len(got) == 0 || got[len(got)-1] != '\n' {
+		t.Error("state file does not end with a newline")
+	}
+}
+
+func TestWriteBumpsSerialEachTime(t *testing.T) {
+	dir := t.TempDir()
+	f := sample()
+	for i := 1; i <= 3; i++ {
+		if err := f.Write(dir); err != nil {
+			t.Fatalf("Write #%d: %v", i, err)
+		}
+	}
+	got, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Serial != 9 {
+		t.Errorf("Serial = %d, want 9 (6 + one per write)", got.Serial)
+	}
+}
+
+func TestTargetGetOrCreate(t *testing.T) {
+	f := &state.File{Version: state.Version, Targets: map[string]*state.TargetState{}}
+	ts := f.Target("openai_assistants")
+	if ts == nil || ts.Resources == nil {
+		t.Fatal("Target did not initialize the target state")
+	}
+	ts.Resources["agent.a"] = &state.Resource{ID: "x", Config: json.RawMessage(`{}`)}
+	if again := f.Target("openai_assistants"); again != ts {
+		t.Error("Target returned a new value for an existing target")
+	}
+}
+
+func readState(t *testing.T, dir string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, state.Filename))
+	if err != nil {
+		t.Fatalf("reading state file: %v", err)
+	}
+	return data
+}

--- a/internal/state/testdata/corrupt/adl.state.json
+++ b/internal/state/testdata/corrupt/adl.state.json
@@ -1,0 +1,1 @@
+{ this is not json

--- a/internal/state/testdata/future_version/adl.state.json
+++ b/internal/state/testdata/future_version/adl.state.json
@@ -1,0 +1,1 @@
+{"version": 3, "serial": 1, "targets": {}}

--- a/internal/state/testdata/golden.state.json
+++ b/internal/state/testdata/golden.state.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "serial": 7,
+  "targets": {
+    "openai_assistants": {
+      "resources": {
+        "agent.geocoder": {
+          "id": "asst_456",
+          "config": {
+            "model": {
+              "id": "gpt-4o-mini",
+              "provider": "openai"
+            }
+          }
+        },
+        "agent.weather": {
+          "id": "asst_123",
+          "config": {
+            "description": "Answers weather questions",
+            "model": {
+              "id": "gpt-4o-mini",
+              "provider": "openai"
+            }
+          },
+          "dependencies": [
+            "agent.geocoder"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/state/testdata/version_missing/adl.state.json
+++ b/internal/state/testdata/version_missing/adl.state.json
@@ -1,0 +1,1 @@
+{"serial": 1, "targets": {}}


### PR DESCRIPTION
Closes #15, closes #14.

Designed as one unit per the issues' coupling; **no OpenAI code** — #16 plugs into the registry this PR leaves empty.

## What this adds

- **`internal/provider`** — the target-agnostic contract and engine (mirrors `internal/build`):
  - `Provider` interface: `Read / Create / Update / Delete / Diff` (SPEC §6). Providers receive only block addresses and neutral JSON value trees — no core or provider types cross the boundary, so it stays plugin-extractable.
  - `DesiredConfig`: renders an agent's closure (model + prompt + tools folded in) into that neutral config, normalized to the `encoding/json` value model.
  - `BuildPlan`: pure-read three-way comparison (spec vs. state vs. remote) → ordered `Change` list + structured `Diagnostic` warnings (drift). `BuildDestroyPlan` plans from state alone.
  - `Apply`: executes in order, **saves state after every operation** — a partial failure loses nothing and a re-run plans exactly the remainder.
- **`internal/provider/providertest`** — in-memory fake (mirrors `buildtest`): structural diff, failure injection, call-order recording. Drives all engine and CLI tests.
- **`internal/state`** — `adl.state.json`: versioned (unknown versions rejected), serial-numbered, byte-deterministic, atomic writes; `.adl.state.lock` local lock with recovery-hint contention errors.
- **`cmd/adl`** — `plan` / `apply` / `destroy` commands: registry keyed by platform target name (like the generator map), rendered plans with per-attribute diffs and drift warnings, countable summary lines, 0/1/2 exit codes.
- **SPEC.md** — new §5.1 (state file) and §5.2 (plan/apply semantics), §6 provider contract rules. ✅ SPEC diff verified present.

## Design decisions not previously covered by SPEC.md

1. **Unit of remote management = agent.** Models/prompts/tools fold into the agent's config ("closure"); standalone remote tool objects deferred.
2. **State stores the full last-applied config, not a hash** (supersedes #14's wording) — drift reports name changed attributes without refetching, at the cost of state size.
3. **`Provider.Diff` is the comparison authority**, called twice per resource: desired-vs-remote decides update/noop; last-applied-vs-remote detects drift.
4. **Single state file, per-target sections** (`targets.<name>.resources`) rather than one file per target — SPEC names `adl.state.json` singular.
5. **State records managed dependencies** so removed-from-spec resources still destroy in reverse dependency order (the module graph no longer knows them).
6. **Plan order: deletes first** (reverse dep order), then creates/updates in topo order. Safe: anything still referenced in spec can't be in the delete set.
7. **Configs live in the JSON value model** (all numbers float64, canonical marshaling) so equality never trips over Go types.
8. **Noop refresh:** if the user edits the spec to match a manual remote change, apply silently refreshes the stale state entry (no remote call) so the drift warning doesn't recur.
9. **Save-failure after create embeds the remote id** in the error — nothing is orphaned silently.
10. **Delete is idempotent by contract**; recovery re-runs converge.
11. **`apply` doesn't prompt in v0**; `plan` exits 0 even with pending changes (no `-detailed-exitcode` yet).
12. **Provider selection by target name** from a cmd-level registry, exactly like codegen generators; provider auth/factories are #16's job.
13. **Diagnostics are structured** (`severity/addr/summary/detail`, JSON-tagged) so `--json` (§9) is a renderer, not a redesign. Hard failures remain Go errors with block-address context.
14. **Lock held for plan too** (not just apply) — consistent reads; exit 2 on contention.
15. **Cross-agent input refs (`DefaultRef`) excluded from configs** — ordering-only in v0, must not trigger remote updates.

## Test plan

- TDD throughout; every validation rule has a negative test (corrupt state, future version, lock contention, provider read failure, corrupt stored config, unknown/wrong-type target selection, unregistered provider).
- Engine: fresh create ordering, in-sync noops, spec-change updates with attribute diffs, reverse-order deletes, remote-deleted recreate + warning, drift converge + warning, stale-state noop refresh, partial-failure recovery, destroy.
- CLI: end-to-end plan→apply→drift→converge→destroy against the fake; plan verified to write nothing.
- `go test ./...`, `go vet ./...`, `gofmt -l .` all clean; real binary driven manually for the empty-registry and usage error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)