### PR TITLE
feat: release automation via GoReleaser + GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,22 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
+
+  # Dry-run of the release pipeline so .goreleaser.yaml breakage is caught on
+  # PRs, not while cutting a release. Publishes nothing.
+  release-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Full history: goreleaser derives the changelog from commits since the
+      # previous tag.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # A release tag must never ship untested.
+      - name: Test
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: pushes the Homebrew formula to weirdGuy/homebrew-tap.
+          # If the secret is absent, .goreleaser.yaml skips the tap upload
+          # instead of failing the release.
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ mcp_servers.json
 # Python artifacts from running generated projects
 **/__pycache__/
 **/.venv/
+
+# GoReleaser output
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,78 @@
+# GoReleaser configuration for the kastor CLI.
+# Releases are tag-driven: pushing a v* tag runs .github/workflows/release.yml,
+# which runs the test suite and then `goreleaser release`.
+version: 2
+
+project_name: kastor
+
+builds:
+  - id: kastor
+    main: ./cmd/kastor
+    binary: kastor
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    # cmd/kastor/root.go defines exactly one build-time variable: main.version.
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - formats: ["tar.gz"]
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^chore"
+      - "^docs"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Other changes
+      order: 999
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+brews:
+  - name: kastor
+    repository:
+      owner: weirdGuy
+      name: homebrew-tap
+      # envOrDefault instead of .Env.X: goreleaser templates error on missing
+      # env keys, and TAP_GITHUB_TOKEN may not exist as a secret yet.
+      token: '{{ envOrDefault "TAP_GITHUB_TOKEN" "" }}'
+    # No token → skip pushing the formula instead of failing the release.
+    skip_upload: '{{ if eq (envOrDefault "TAP_GITHUB_TOKEN" "") "" }}true{{ else }}false{{ end }}'
+    directory: Formula
+    homepage: "https://github.com/weirdGuy/kastor"
+    description: "Terraform for AI agents — declarative agent specs in HCL"
+    license: "Apache-2.0"
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    test: |
+      system "#{bin}/kastor version"
+    install: |
+      bin.install "kastor"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,7 @@ gofmt -l .                     # formatting check (must be clean)
 - `kastor validate` must stay fast — it runs on every save in editor integrations later
 - When adding a block field: update schema struct → validation → parser test fixtures → SPEC.md if it's a design change
 - Before claiming a milestone or feature is code complete, attempt its acceptance command (e.g. `kastor validate` / `kastor build` on the examples) and confirm the output — passing tests alone don't count
+
+## Releases
+
+Tag-driven: pushing a `v*` tag runs `.github/workflows/release.yml`, which runs the full test suite and then GoReleaser (`.goreleaser.yaml`) — six platform/arch binaries, archives, `checksums.txt`, grouped changelog, GitHub release, and (only if the `TAP_GITHUB_TOKEN` secret exists) a Homebrew formula push to `weirdGuy/homebrew-tap`. CI dry-runs the config on every PR via `goreleaser release --snapshot --clean`, so validate release changes there — never by pushing a tag. The version string is injected into `main.version` via ldflags; `scripts/install.sh` depends on the archive naming template, keep them in sync.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ Kastor is "Terraform for AI agents." Agents today are defined imperatively insid
 
 The full design lives in [SPEC.md](SPEC.md).
 
+## Install
+
+Homebrew:
+
+```sh
+brew tap weirdGuy/tap && brew install kastor
+```
+
+Install script (verifies the release checksum, installs to `/usr/local/bin` or `~/.local/bin`, never sudo):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/weirdGuy/kastor/main/scripts/install.sh | sh
+```
+
+With Go 1.26+:
+
+```sh
+go install github.com/weirdGuy/kastor/cmd/kastor@latest
+```
+
+Or download an archive for your platform from the [releases page](https://github.com/weirdGuy/kastor/releases), verify it against `checksums.txt`, and put the `kastor` binary on your PATH.
+
 ## Quickstart: build the weather example
 
 Prerequisites: Go 1.26+, Python 3.11+, an OpenAI API key, and a [Tavily](https://tavily.com) API key (the example's search tool runs against Tavily's hosted MCP server).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Install the latest kastor release from GitHub.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/weirdGuy/kastor/main/scripts/install.sh | sh
+#
+# Environment:
+#   KASTOR_INSTALL_DIR  Override the install directory. Defaults to
+#                       /usr/local/bin when writable, otherwise ~/.local/bin.
+#                       Never invokes sudo.
+set -eu
+
+REPO="weirdGuy/kastor"
+
+err() {
+    echo "install.sh: $1" >&2
+    exit 1
+}
+
+command -v curl >/dev/null 2>&1 || err "curl is required"
+command -v tar >/dev/null 2>&1 || err "tar is required"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$os" in
+    linux | darwin) ;;
+    *) err "unsupported OS: $os (on Windows, download the zip from https://github.com/${REPO}/releases)" ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+    x86_64 | amd64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *) err "unsupported architecture: $arch" ;;
+esac
+
+tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+    grep -o '"tag_name": *"[^"]*"' | head -n 1 | cut -d '"' -f 4)
+[ -n "$tag" ] || err "could not determine the latest release tag"
+version=${tag#v}
+
+archive="kastor_${version}_${os}_${arch}.tar.gz"
+base_url="https://github.com/${REPO}/releases/download/${tag}"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+echo "Downloading kastor ${tag} (${os}/${arch})..."
+curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}"
+curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/checksums.txt"
+
+checksum_line=$(grep "[[:space:]]${archive}\$" "${tmpdir}/checksums.txt") ||
+    err "no entry for ${archive} in checksums.txt"
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && echo "$checksum_line" | sha256sum -c - >/dev/null) ||
+        err "checksum verification failed for ${archive}"
+elif command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && echo "$checksum_line" | shasum -a 256 -c - >/dev/null) ||
+        err "checksum verification failed for ${archive}"
+else
+    err "sha256sum or shasum is required to verify the download"
+fi
+
+tar -xzf "${tmpdir}/${archive}" -C "$tmpdir" kastor
+
+if [ -n "${KASTOR_INSTALL_DIR:-}" ]; then
+    install_dir=$KASTOR_INSTALL_DIR
+    mkdir -p "$install_dir"
+elif [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+    install_dir=/usr/local/bin
+else
+    install_dir="${HOME}/.local/bin"
+    mkdir -p "$install_dir"
+fi
+
+cp "${tmpdir}/kastor" "${install_dir}/kastor"
+chmod 0755 "${install_dir}/kastor"
+echo "Installed kastor ${tag} to ${install_dir}/kastor"
+
+case ":${PATH}:" in
+    *":${install_dir}:"*) ;;
+    *) echo "Note: ${install_dir} is not on your PATH" >&2 ;;
+esac


### PR DESCRIPTION
## Summary

Tag-driven release pipeline for the `kastor` CLI:

- **`.goreleaser.yaml`** — six targets (linux/darwin/windows × amd64/arm64), `CGO_ENABLED=0`, version injected into the existing `main.version` ldflags variable; tar.gz archives (zip on Windows) bundling LICENSE + README.md; `checksums.txt`; grouped changelog excluding `chore`/`docs` commits; Homebrew formula for `weirdGuy/homebrew-tap` guarded by templated `skip_upload` — a missing `TAP_GITHUB_TOKEN` skips the tap push instead of failing the release.
- **`.github/workflows/release.yml`** — triggers on `v*` tags, `fetch-depth: 0` for the changelog, runs the full test suite before `goreleaser release`.
- **CI snapshot job** — `goreleaser release --snapshot --clean` on every PR so config breakage is caught before tag time.
- **`scripts/install.sh`** — POSIX sh, shellcheck-clean; detects OS/arch, verifies against `checksums.txt`, installs to `/usr/local/bin` or `~/.local/bin`, never sudo.
- README install section (brew / curl|sh / go install / manual) and a CLAUDE.md "Releases" note.

No tag was created and nothing was published — config and dry-run only.

## Verification

- `goreleaser release --snapshot --clean` locally: all six platform/arch binaries + archives + checksums.txt + formula produced.
- linux/amd64 binary in a container: `kastor version` prints the injected snapshot version; `kastor validate examples/weather/` → "Success! Module is valid".
- `go test ./...`, `go vet ./...`, `gofmt -l .` all clean; `shellcheck -s sh scripts/install.sh` zero findings.

## Open decisions (proposed, not implemented)

1. **Archive naming** — used GoReleaser's default `kastor_<version>_<os>_<arch>` (install.sh depends on it).
2. **commit/date in `kastor version`** — `cmd/kastor/root.go` defines only `main.version`; per instructions I did not invent new variables. Adding `commit`/`date` needs a small root.go + test change.
3. **`brews` deprecation** — latest GoReleaser deprecates `brews` in favor of `homebrew_casks`. Kept `brews` since a formula was explicitly requested and it still works (warning only); migrate before GoReleaser v3.
4. **Docker image of the CLI** — not implemented; could add `dockers`/`docker_manifests` publishing to ghcr.io in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)