### PR TITLE
kastor plan: acceptance on examples/weather via a built-in memory platform (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Working today:
 - parse `.agent`, `.tool`, `.prompt`, and `kastor.hcl`
 - validate references and prompt variables
 - build runnable LangGraph projects
+- `kastor plan` / `kastor apply` / `kastor destroy` against the built-in in-memory platform — local state file, three-way diffs, drift detection
 - examples: [weather agent](https://github.com/weirdGuy/kastor/tree/main/examples/weather), [content scheduler](https://github.com/weirdGuy/kastor/tree/main/examples/scheduler) agent
 
 Planned for v0:
-- `kastor plan/apply`
-- local state file and drift detection
-- Deploy to aws/azure platforms.
+- hosted platform providers (OpenAI Assistants first, then AWS/Azure)
 
 _This is not another agent runtime/framework._
 
@@ -48,6 +47,19 @@ agent "weather" {
   }
 }
 ```
+
+And `kastor plan` shows what `kastor apply` would change on a platform target — a three-way comparison of the spec, the state file, and the remote platform. The weather example targets the built-in in-memory platform, so it works with no credentials:
+
+```console
+$ kastor plan examples/weather/
+  + agent.forecast (not in state)
+  + agent.geocoder (not in state)
+  + agent.weather (not in state)
+
+Plan for target.memory: 3 to create, 0 to update, 0 to delete, 0 unchanged.
+```
+
+Plan is a pure read — it never touches remote resources or the state file. Updates show attribute-level diffs, and out-of-band remote changes surface as drift warnings.
 
 ## Install
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -221,6 +221,8 @@ target "openai_assistants" {
 - `codegen` targets require `output` and do not allow `auth`.
 - `platform` targets do not allow `output`; `auth` is optional (ambient credentials — env vars, instance roles — are the common case).
 - Fields that are meaningless for a target's type are errors, not ignored (configs rot through silent acceptance).
+- **A platform target's label selects its provider implementation**, exactly as a codegen target's label selects its generator: `target "openai_assistants"` binds to the OpenAI Assistants reconciler, `target "memory"` to the built-in in-memory platform. A label with no registered provider is an error naming the available providers. (A separate `provider` attribute is deliberately deferred until something forces it — e.g. two targets on the same platform kind in one module.)
+- The `memory` platform is built in: an **ephemeral in-memory store** so plan/apply can be demonstrated and exercised — examples, onboarding, CI — with no credentials and no network. `auth` on it is an error (meaningless fields, again). Its remote objects die with the process, so a later invocation's plan truthfully reports previously applied resources as remote-missing drift.
  
 ---
  
@@ -295,6 +297,8 @@ Per resource, in the module's topological order (deletes first, in reverse depen
 
 **Drift** (remote changed outside kastor) is detected by diffing the *last-applied* config against the remote and reported as a warning naming the changed attributes; apply converges the remote back to the spec. When the user instead edits the spec to match a manual remote change, the plan is a no-op and apply silently refreshes the stale state entry (no remote call), so the warning does not recur.
 
+**Plan output.** One line per pending change, in execution order: `+` create, `~` update, `-` delete, with the reason in parentheses on creates and deletes, and one indented `path: old → new` line per attribute diff under updates (values render as compact JSON, truncated so a prompt body cannot flood the plan). An attribute diff is `{path, old, new}` with dotted paths (`model.id`, `tools[0].source.uri`); `old` is null when an attribute is being added, `new` null when it is being removed. Warnings precede the summary. The summary line is countable and per-target — `Plan for target.<name>: N to create, M to update, K to delete, J unchanged.` — or `No changes for target.<name>: remote matches the spec (N resources).` when nothing is pending. The whole plan (target, ordered changes, attribute diffs, diagnostics) is one serializable tree, so the `--json` rendering (§9) is a second renderer over the same data, not a second pipeline.
+
 `kastor apply` executes the plan in order and stops at the first failure; everything applied up to that point is already saved in state, and the error states what failed, what had been applied, and — if a resource was created remotely but saving state failed — the remote id, so nothing is orphaned silently. `kastor apply` does not prompt for confirmation in v0. `kastor destroy` deletes everything in state in reverse dependency order.
 
 Diagnostics from plan/apply are structured (severity, block address, summary, detail) so a machine-readable `--json` rendering (§9) is a renderer, not a redesign.
@@ -314,6 +318,7 @@ internal/
     langgraph/      target: LangGraph (Python)
     crewai/         target: CrewAI (Python)
   provider/         platform reconcilers
+    memory/         built-in in-memory platform (demos, examples, CI)
     openai/         OpenAI Assistants API
     bedrock/        AWS Bedrock Agents
   state/            state file read/write, locking, diff

--- a/cmd/kastor/plan_test.go
+++ b/cmd/kastor/plan_test.go
@@ -160,6 +160,31 @@ func TestPlanApplyDestroyEndToEnd(t *testing.T) {
 	}
 }
 
+// TestPlanWeatherExample is the issue #17 acceptance: a bare kastor plan on
+// examples/weather must produce a clean first plan against the built-in
+// memory platform — this output is the README demo. No fake registration:
+// it exercises the provider registry the shipped binary uses.
+func TestPlanWeatherExample(t *testing.T) {
+	dir := copyModule(t, filepath.Join("..", "..", "examples", "weather"))
+	out, err := runCLI(t, "plan", dir)
+	if err != nil {
+		t.Fatalf("plan: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"+ agent.forecast (not in state)",
+		"+ agent.geocoder (not in state)",
+		"+ agent.weather (not in state)",
+		"Plan for target.memory: 3 to create, 0 to update, 0 to delete, 0 unchanged.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan output missing %q:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, state.Filename)); !os.IsNotExist(err) {
+		t.Error("plan created a state file — plan must be a pure read")
+	}
+}
+
 func TestPlatformCommandErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -196,6 +221,13 @@ func TestPlatformCommandErrors(t *testing.T) {
 			dir:      "testdata/platform_no_provider",
 			wantCode: 1,
 			wantOut:  []string{"target.openai_assistants", "no platform provider"},
+		},
+		{
+			name:     "memory target rejects auth",
+			args:     []string{"plan"},
+			dir:      "testdata/platform_memory_auth",
+			wantCode: 1,
+			wantOut:  []string{"target.memory", "auth block found", "in-memory platform takes no credentials"},
 		},
 		{
 			name:     "invalid module never plans",

--- a/cmd/kastor/platform.go
+++ b/cmd/kastor/platform.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/weirdGuy/kastor/internal/module"
 	"github.com/weirdGuy/kastor/internal/provider"
+	"github.com/weirdGuy/kastor/internal/provider/memory"
 	"github.com/weirdGuy/kastor/internal/schema"
 	"github.com/weirdGuy/kastor/internal/state"
 )
@@ -16,7 +17,9 @@ import (
 // the target label doubles as the provider selector, exactly like codegen
 // target names select generators (see cmd/kastor/build.go). Issue #16
 // registers "openai_assistants" here.
-var providerFactories = map[string]func(*schema.Target) (provider.Provider, error){}
+var providerFactories = map[string]func(*schema.Target) (provider.Provider, error){
+	"memory": memory.Factory,
+}
 
 // platformJob is one reconcile unit: a platform target with its resolved
 // provider, sharing the module, graph, and state with its siblings.

--- a/cmd/kastor/testdata/platform_memory_auth/agents.agent
+++ b/cmd/kastor/testdata/platform_memory_auth/agents.agent
@@ -1,0 +1,24 @@
+agent "geocoder" {
+  model = model.fast
+
+  input "place" {
+    type = string
+  }
+
+  output "coordinates" {
+    type = string
+  }
+}
+
+agent "weather" {
+  model = model.fast
+
+  input "coordinates" {
+    type    = string
+    default = agent.geocoder.output.coordinates
+  }
+
+  output "report" {
+    type = string
+  }
+}

--- a/cmd/kastor/testdata/platform_memory_auth/kastor.hcl
+++ b/cmd/kastor/testdata/platform_memory_auth/kastor.hcl
@@ -1,0 +1,14 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+# Invalid: auth is meaningless on the in-memory platform and must be an
+# error, not ignored.
+target "memory" {
+  type = "platform"
+
+  auth {
+    api_key_env = "NOPE"
+  }
+}

--- a/examples/weather/kastor.hcl
+++ b/examples/weather/kastor.hcl
@@ -14,11 +14,9 @@ target "langgraph" {
   output = "./gen/langgraph"
 }
 
-# Platform target with explicit auth (also valid without auth: ambient credentials)
-target "openai_assistants" {
+# Platform target -> `kastor plan` / `kastor apply` against the built-in
+# ephemeral in-memory platform: no credentials, no network. Swap for a real
+# platform target (e.g. "openai_assistants", issue #16) once one ships.
+target "memory" {
   type = "platform"
-
-  auth {
-    api_key_env = "OPENAI_API_KEY"
-  }
 }

--- a/internal/provider/memory/memory.go
+++ b/internal/provider/memory/memory.go
@@ -1,0 +1,173 @@
+// Package memory is the built-in in-memory platform provider: a real,
+// registered plan/apply target whose "platform" is a map in process memory.
+// It exists so the reconcile path can be demonstrated and exercised —
+// examples, onboarding, CI — without credentials or a network.
+//
+// The platform is ephemeral: remote objects vanish when the process exits.
+// A plan run after an apply from an earlier invocation therefore reports
+// every tracked resource as deleted outside kastor (drift) and recreates it
+// on the next apply — the truthful answer for a platform that forgot
+// everything, not a bug.
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/weirdGuy/kastor/internal/provider"
+	"github.com/weirdGuy/kastor/internal/schema"
+)
+
+// Provider implements provider.Provider over a map in process memory. Its
+// remote objects are stored verbatim as the desired configs that created
+// them, so Diff is a generic structural comparison over the JSON value
+// model (DiffObjects).
+type Provider struct {
+	// Objects maps remote id → stored object (a deep copy of the config
+	// that created or last updated it).
+	Objects map[string]provider.Object
+
+	nextID int
+}
+
+// New returns an empty in-memory platform. Remote ids are assigned as
+// mem-1, mem-2, … in creation order.
+func New() *Provider {
+	return &Provider{Objects: map[string]provider.Object{}}
+}
+
+// Factory adapts New to the CLI's provider registry, validating the target
+// block first: auth is meaningless on an in-memory platform, and meaningless
+// fields are errors, not ignored (SPEC.md §3.5).
+func Factory(tgt *schema.Target) (provider.Provider, error) {
+	if tgt.Auth != nil {
+		return nil, fmt.Errorf("auth block found, but the in-memory platform takes no credentials — remove auth from the target block")
+	}
+	return New(), nil
+}
+
+// Read implements provider.Provider.
+func (p *Provider) Read(_ context.Context, id string) (provider.Object, bool, error) {
+	obj, ok := p.Objects[id]
+	if !ok {
+		return nil, false, nil
+	}
+	return deepCopy(obj), true, nil
+}
+
+// Create implements provider.Provider.
+func (p *Provider) Create(_ context.Context, desired *provider.Resource) (string, error) {
+	p.nextID++
+	id := fmt.Sprintf("mem-%d", p.nextID)
+	p.Objects[id] = deepCopy(desired.Config)
+	return id, nil
+}
+
+// Update implements provider.Provider.
+func (p *Provider) Update(_ context.Context, id string, desired *provider.Resource) error {
+	if _, ok := p.Objects[id]; !ok {
+		return fmt.Errorf("no remote object %s", id)
+	}
+	p.Objects[id] = deepCopy(desired.Config)
+	return nil
+}
+
+// Delete implements provider.Provider. Deleting a missing id succeeds, as
+// the contract requires.
+func (p *Provider) Delete(_ context.Context, id string) error {
+	delete(p.Objects, id)
+	return nil
+}
+
+// Diff implements provider.Provider via DiffObjects: the stored objects are
+// exactly the neutral configs that created them, so the generic structural
+// comparison is this platform's authoritative diff.
+func (p *Provider) Diff(desired *provider.Resource, remote provider.Object) ([]provider.AttrDiff, error) {
+	return DiffObjects(desired.Config, remote), nil
+}
+
+// DiffObjects structurally compares two JSON value trees: maps diff by
+// sorted key union, same-length arrays element-wise, anything else as a
+// leaf. Old is the remote value, New the desired one. Output order is
+// deterministic (sorted key order). Exported so providertest's fake diffs
+// with the same algorithm and the two can never disagree.
+func DiffObjects(desired, remote provider.Object) []provider.AttrDiff {
+	var diffs []provider.AttrDiff
+	diffValue("", desired, remote, &diffs)
+	return diffs
+}
+
+// diffValue appends the differences between desired and remote at path.
+func diffValue(path string, desired, remote any, out *[]provider.AttrDiff) {
+	switch d := desired.(type) {
+	case map[string]any:
+		r, ok := remote.(map[string]any)
+		if !ok {
+			appendLeaf(path, desired, remote, out)
+			return
+		}
+		keys := map[string]bool{}
+		for k := range d {
+			keys[k] = true
+		}
+		for k := range r {
+			keys[k] = true
+		}
+		sorted := make([]string, 0, len(keys))
+		for k := range keys {
+			sorted = append(sorted, k)
+		}
+		sort.Strings(sorted)
+		for _, k := range sorted {
+			dv, inD := d[k]
+			rv, inR := r[k]
+			sub := k
+			if path != "" {
+				sub = path + "." + k
+			}
+			switch {
+			case !inR:
+				*out = append(*out, provider.AttrDiff{Path: sub, Old: nil, New: dv})
+			case !inD:
+				*out = append(*out, provider.AttrDiff{Path: sub, Old: rv, New: nil})
+			default:
+				diffValue(sub, dv, rv, out)
+			}
+		}
+	case []any:
+		r, ok := remote.([]any)
+		if !ok || len(r) != len(d) {
+			appendLeaf(path, desired, remote, out)
+			return
+		}
+		for i := range d {
+			diffValue(fmt.Sprintf("%s[%d]", path, i), d[i], r[i], out)
+		}
+	default:
+		appendLeaf(path, desired, remote, out)
+	}
+}
+
+// appendLeaf records a leaf-level difference, if there is one.
+func appendLeaf(path string, desired, remote any, out *[]provider.AttrDiff) {
+	if !reflect.DeepEqual(desired, remote) {
+		*out = append(*out, provider.AttrDiff{Path: path, Old: remote, New: desired})
+	}
+}
+
+// deepCopy clones a JSON value tree so the store never shares structure
+// with callers.
+func deepCopy(obj provider.Object) provider.Object {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(fmt.Sprintf("memory: object is not a JSON value tree: %v", err))
+	}
+	var out provider.Object
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(fmt.Sprintf("memory: %v", err))
+	}
+	return out
+}

--- a/internal/provider/memory/memory_test.go
+++ b/internal/provider/memory/memory_test.go
@@ -1,0 +1,127 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/weirdGuy/kastor/internal/provider"
+	"github.com/weirdGuy/kastor/internal/schema"
+)
+
+func TestLifecycle(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	// Create assigns sequential ids and stores the config.
+	id, err := p.Create(ctx, &provider.Resource{Addr: "agent.a", Config: provider.Object{"model": map[string]any{"id": "gpt-4o-mini"}}})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if id != "mem-1" {
+		t.Errorf("first id = %q, want mem-1", id)
+	}
+	if id2, _ := p.Create(ctx, &provider.Resource{Addr: "agent.b", Config: provider.Object{}}); id2 != "mem-2" {
+		t.Errorf("second id = %q, want mem-2", id2)
+	}
+
+	// Read returns the stored object.
+	obj, found, err := p.Read(ctx, id)
+	if err != nil || !found {
+		t.Fatalf("read: found=%v err=%v", found, err)
+	}
+	if diff := cmp.Diff(provider.Object{"model": map[string]any{"id": "gpt-4o-mini"}}, obj); diff != "" {
+		t.Errorf("read object mismatch (-want +got):\n%s", diff)
+	}
+
+	// Update replaces the stored object.
+	if err := p.Update(ctx, id, &provider.Resource{Addr: "agent.a", Config: provider.Object{"model": map[string]any{"id": "gpt-4o"}}}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	obj, _, _ = p.Read(ctx, id)
+	if got := obj["model"].(map[string]any)["id"]; got != "gpt-4o" {
+		t.Errorf("model.id after update = %v, want gpt-4o", got)
+	}
+
+	// Delete removes the object; reading it reports found=false, no error.
+	if err := p.Delete(ctx, id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, found, err := p.Read(ctx, id); found || err != nil {
+		t.Errorf("read after delete: found=%v err=%v, want found=false err=nil", found, err)
+	}
+}
+
+func TestDeleteIsIdempotent(t *testing.T) {
+	if err := New().Delete(context.Background(), "mem-99"); err != nil {
+		t.Errorf("deleting a missing id must succeed, got %v", err)
+	}
+}
+
+func TestUpdateUnknownIDFails(t *testing.T) {
+	err := New().Update(context.Background(), "mem-99", &provider.Resource{Addr: "agent.a", Config: provider.Object{}})
+	if err == nil || !strings.Contains(err.Error(), "mem-99") {
+		t.Errorf("update of unknown id: err = %v, want error naming mem-99", err)
+	}
+}
+
+// The store must never share structure with callers: mutating a config
+// after Create, or an object returned by Read, must not change the store.
+func TestStoreIsIsolatedFromCallers(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	cfg := provider.Object{"model": map[string]any{"id": "gpt-4o-mini"}}
+	id, _ := p.Create(ctx, &provider.Resource{Addr: "agent.a", Config: cfg})
+	cfg["model"].(map[string]any)["id"] = "mutated-after-create"
+
+	got, _, _ := p.Read(ctx, id)
+	if v := got["model"].(map[string]any)["id"]; v != "gpt-4o-mini" {
+		t.Fatalf("store shares structure with the creator: model.id = %v", v)
+	}
+
+	got["model"].(map[string]any)["id"] = "mutated-after-read"
+	again, _, _ := p.Read(ctx, id)
+	if v := again["model"].(map[string]any)["id"]; v != "gpt-4o-mini" {
+		t.Errorf("store shares structure with readers: model.id = %v", v)
+	}
+}
+
+func TestDiffMatchesStoredObjects(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+	id, _ := p.Create(ctx, &provider.Resource{Addr: "agent.a", Config: provider.Object{"model": map[string]any{"id": "gpt-4o-mini"}}})
+	remote, _, _ := p.Read(ctx, id)
+
+	// In sync: empty diff.
+	diffs, err := p.Diff(&provider.Resource{Addr: "agent.a", Config: provider.Object{"model": map[string]any{"id": "gpt-4o-mini"}}}, remote)
+	if err != nil || len(diffs) != 0 {
+		t.Errorf("in-sync diff = %v, %v; want empty, nil", diffs, err)
+	}
+
+	// Spec change: one attribute diff, remote as old, desired as new.
+	diffs, err = p.Diff(&provider.Resource{Addr: "agent.a", Config: provider.Object{"model": map[string]any{"id": "gpt-4o"}}}, remote)
+	if err != nil {
+		t.Fatalf("diff: %v", err)
+	}
+	want := []provider.AttrDiff{{Path: "model.id", Old: "gpt-4o-mini", New: "gpt-4o"}}
+	if diff := cmp.Diff(want, diffs); diff != "" {
+		t.Errorf("diff mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFactory(t *testing.T) {
+	p, err := Factory(&schema.Target{Name: "memory", Type: "platform"})
+	if err != nil || p == nil {
+		t.Errorf("Factory on a plain platform target: %v, %v; want a provider, nil", p, err)
+	}
+
+	// Negative: auth is meaningless on an in-memory platform and must be
+	// rejected, not ignored.
+	_, err = Factory(&schema.Target{Name: "memory", Type: "platform", Auth: &schema.Auth{APIKeyEnv: "NOPE"}})
+	if err == nil || !strings.Contains(err.Error(), "auth") {
+		t.Errorf("Factory with auth: err = %v, want error naming the auth block", err)
+	}
+}

--- a/internal/provider/providertest/providertest.go
+++ b/internal/provider/providertest/providertest.go
@@ -1,18 +1,18 @@
 // Package providertest provides an in-memory Provider for testing the
 // plan/apply engine and CLI without a real platform (mirroring buildtest
 // for the codegen engine). Its remote objects are stored verbatim as the
-// desired configs that created them, so its Diff is a generic structural
-// comparison over the JSON value model.
+// desired configs that created them, and its Diff delegates to the shipped
+// memory provider's structural comparison, so the fake and the real
+// in-memory platform can never disagree.
 package providertest
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"sort"
 
 	"github.com/weirdGuy/kastor/internal/provider"
+	"github.com/weirdGuy/kastor/internal/provider/memory"
 )
 
 // Fake is an in-memory provider.Provider. Zero-configuration tests just
@@ -91,74 +91,15 @@ func (f *Fake) Delete(_ context.Context, id string) error {
 	return nil
 }
 
-// Diff implements provider.Provider with a generic structural comparison:
-// maps diff by sorted key union, same-length arrays element-wise, anything
-// else as a leaf. Old is the remote value, New the desired one.
+// Diff implements provider.Provider by delegating to the memory provider's
+// structural comparison (maps by sorted key union, same-length arrays
+// element-wise, anything else as a leaf; Old is the remote value, New the
+// desired one).
 func (f *Fake) Diff(desired *provider.Resource, remote provider.Object) ([]provider.AttrDiff, error) {
 	if err := f.call("diff", desired.Addr); err != nil {
 		return nil, err
 	}
-	var diffs []provider.AttrDiff
-	diffValue("", desired.Config, remote, &diffs)
-	return diffs, nil
-}
-
-// diffValue appends the differences between desired and remote at path.
-func diffValue(path string, desired, remote any, out *[]provider.AttrDiff) {
-	switch d := desired.(type) {
-	case map[string]any:
-		r, ok := remote.(map[string]any)
-		if !ok {
-			appendLeaf(path, desired, remote, out)
-			return
-		}
-		keys := map[string]bool{}
-		for k := range d {
-			keys[k] = true
-		}
-		for k := range r {
-			keys[k] = true
-		}
-		sorted := make([]string, 0, len(keys))
-		for k := range keys {
-			sorted = append(sorted, k)
-		}
-		sort.Strings(sorted)
-		for _, k := range sorted {
-			dv, inD := d[k]
-			rv, inR := r[k]
-			sub := k
-			if path != "" {
-				sub = path + "." + k
-			}
-			switch {
-			case !inR:
-				*out = append(*out, provider.AttrDiff{Path: sub, Old: nil, New: dv})
-			case !inD:
-				*out = append(*out, provider.AttrDiff{Path: sub, Old: rv, New: nil})
-			default:
-				diffValue(sub, dv, rv, out)
-			}
-		}
-	case []any:
-		r, ok := remote.([]any)
-		if !ok || len(r) != len(d) {
-			appendLeaf(path, desired, remote, out)
-			return
-		}
-		for i := range d {
-			diffValue(fmt.Sprintf("%s[%d]", path, i), d[i], r[i], out)
-		}
-	default:
-		appendLeaf(path, desired, remote, out)
-	}
-}
-
-// appendLeaf records a leaf-level difference, if there is one.
-func appendLeaf(path string, desired, remote any, out *[]provider.AttrDiff) {
-	if !reflect.DeepEqual(desired, remote) {
-		*out = append(*out, provider.AttrDiff{Path: path, Old: remote, New: desired})
-	}
+	return memory.DiffObjects(desired.Config, remote), nil
 }
 
 // deepCopy clones a JSON value tree so the fake's store never shares


### PR DESCRIPTION
Closes #17.

## What this is

Issue #17's engine and CLI scope turned out to be **already merged in #43** (three-way plan engine, validate-first CLI wiring, `--target`, deterministic ordering, renderer, exit codes, and tests for every scenario in the issue). What was actually missing was the acceptance path: the provider registry was empty, so `kastor plan examples/weather/` could not run. This PR closes that gap:

- **`internal/provider/memory`** — a real, shipped in-memory platform provider (ephemeral, credential-free), registered under target label `memory`. `providertest`'s fake now delegates its structural diff to `memory.DiffObjects`, so the test fake and the shipped provider share one comparison algorithm.
- **examples/weather** swaps its providerless `openai_assistants` target for `target "memory"` until #16 lands, so the bare acceptance command works.
- **Negative test**: `auth` on a memory target is an error (meaningless fields are errors), asserted end-to-end through the CLI.
- **Acceptance test** pins the README demo: `TestPlanWeatherExample` runs a bare plan on a copy of examples/weather through the real registry.

## Acceptance output (now in the README)

```console
$ kastor plan examples/weather/
  + agent.forecast (not in state)
  + agent.geocoder (not in state)
  + agent.weather (not in state)

Plan for target.memory: 3 to create, 0 to update, 0 to delete, 0 unchanged.
```

## Design decisions surfaced (now in SPEC.md)

1. **Target→provider binding is label-based** (§3.5): the platform target's label selects the provider, exactly as codegen target labels select generators. This was ratified by #43's code but undocumented. A separate `provider` attribute is deliberately deferred until something forces it.
2. **The `memory` platform ships in the binary** (§3.5): ephemeral by design — objects die with the process, so a plan in a later invocation truthfully reports previously applied resources as remote-missing drift. `auth` on it is an error.
3. **Plan output format + attribute diff shape** (§5.2): `+`/`~`/`-` markers, `path: old → new` attribute lines, countable per-target summary; the attribute diff is `{path, old, new}` and the whole plan is one serializable tree, so `--json` (§9) stays a renderer, not a redesign. The ratified summary wording (`Plan for target.<name>: N to create, …`) is kept over the issue's sketch (`X to add, Y to change…`).
4. **Locking**: per #14's ratified semantics (SPEC §5.1), plan takes the local state lock for its duration; it remains a pure read (only `Read`/`Diff`, no state writes) — verified by tests.

## Checklist

- [x] `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] Acceptance command run and output confirmed (above), plus full plan→apply→replan lifecycle exercised manually
- [x] Negative test per new validation rule (auth on memory target)
- [x] SPEC.md diff present in this PR (§3.5, §5.2, §6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)