### PR TITLE
docs: consistency sweep post-#56 landscape realignment (#58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Kastor is "Terraform for AI agents": a declarative HCL spec compiled to agent fr
 ## What this is
 
 - Go CLI (`kastor`) that parses `.agent`, `.tool`, `.prompt`, and `kastor.hcl` project files
-- Two execution paths: `kastor build` (codegen → LangGraph first) and `kastor plan/apply` (platform reconciler → OpenAI Assistants first)
+- Two execution paths: `kastor build` (codegen → LangGraph shipped, eve planned) and `kastor plan/apply` (platform reconciler → provider TBD; candidates: Bedrock AgentCore, Dify)
 - Non-goals for v0: being a runtime, executing agents, eval harnesses
 
 ## Architecture
@@ -17,8 +17,8 @@ internal/
   schema/           typed config structs, validation
   module/           directory walk → symbol table, cross-file reference resolution
   graph/            DAG construction, cycle detection, topo sort
-  build/            codegen engine + per-target generators (build/langgraph/)
-  provider/         platform reconcilers (provider/openai/)
+  build/            codegen engine + per-target generators (build/langgraph/, build/eve/, build/crewai/)
+  provider/         platform reconcilers (provider/memory/; TBD — candidates: agentcore/, dify/)
   state/            state file read/write, locking, diff
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Working today:
 
 Planned for v0:
 
-- hosted platform providers
+- a second codegen target: Vercel eve
+- hosted platform providers (in design — candidates: Bedrock AgentCore, Dify)
 
 Kastor is **not** an agent runtime.
 
@@ -209,7 +210,7 @@ References also build the dependency graph. A reference like `agent.forecast.out
 
 Kastor is not an agent runtime.
 
-Frameworks like LangGraph still execute agents. Hosted platforms like OpenAI Assistants still run managed agents. Kastor sits above them as the declarative source-of-truth layer: model, prompts, tools, inputs, outputs, dependencies, and targets.
+Frameworks like LangGraph still execute agents. Hosted platforms like Dify still run managed agents. Kastor sits above them as the declarative source-of-truth layer: model, prompts, tools, inputs, outputs, dependencies, and targets.
 
 Kastor also does not try to standardize the full behavior or control loop of an agent. That layer is still changing quickly. The narrower bet is that the outer contract around agents should be reviewable, versionable, and diffable.
 

--- a/cmd/kastor/platform.go
+++ b/cmd/kastor/platform.go
@@ -15,8 +15,9 @@ import (
 
 // providerFactories maps a platform target's name to its provider factory:
 // the target label doubles as the provider selector, exactly like codegen
-// target names select generators (see cmd/kastor/build.go). Issue #16
-// registers "openai_assistants" here.
+// target names select generators (see cmd/kastor/build.go). The hosted
+// provider registers here once selected (TBD — candidates: Bedrock
+// AgentCore, Dify; SPEC.md §8).
 var providerFactories = map[string]func(*schema.Target) (provider.Provider, error){
 	"memory": memory.Factory,
 }

--- a/examples/weather/kastor.hcl
+++ b/examples/weather/kastor.hcl
@@ -16,7 +16,8 @@ target "langgraph" {
 
 # Platform target -> `kastor plan` / `kastor apply` against the built-in
 # ephemeral in-memory platform: no credentials, no network. Swap for a real
-# platform target (e.g. "openai_assistants", issue #16) once one ships.
+# platform target once one ships (provider TBD -- candidates: Bedrock
+# AgentCore, Dify; SPEC.md section 8).
 target "memory" {
   type = "platform"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,7 @@
 // it renders a loaded module into desired resource configurations, compares
 // them three ways (spec vs. state vs. remote) into a plan, and executes
 // plans against a platform through the Provider contract. Per-platform
-// reconcilers live in subpackages (provider/openai, ...) and implement
+// reconcilers live in subpackages (provider/memory, ...) and implement
 // Provider; nothing platform-specific appears in this package.
 //
 // The contract deliberately traffics only in serializable, provider-neutral

--- a/mintlify/AGENTS.md
+++ b/mintlify/AGENTS.md
@@ -26,7 +26,7 @@
 
 ## Content boundaries
 
-- Do not claim OpenAI Assistants support, because this platform is phasing out of existence.
+- Do not claim support for a specific hosted platform provider; selection is TBD (candidates: Bedrock AgentCore, Dify). Never present OpenAI Assistants or Bedrock Agents Classic as targets — both are sunset.
 - Do not claim package-manager installation exists unless verified.
 - Do not document `adl.hcl` as implemented unless the parser supports it.
 - Do not document `kastor compile`; use `kastor build`.

--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -40,8 +40,8 @@ That shape makes agent changes easier to review in pull requests and easier to r
 
 Kastor has two paths:
 
-- `kastor build` compiles a module into runnable framework code. LangGraph is the implemented first codegen target.
-- `kastor plan` and `kastor apply` reconcile platform targets using state, diffs, and dependency ordering. The built-in `memory` provider works today for local demos and tests. Hosted providers are planned for v0.
+- `kastor build` compiles a module into runnable framework code. LangGraph is the implemented first codegen target; a Vercel eve target is planned.
+- `kastor plan` and `kastor apply` reconcile platform targets using state, diffs, and dependency ordering. The built-in `memory` provider works today for local demos and tests. A hosted provider is planned for v0 (TBD — candidates: Bedrock AgentCore, Dify).
 
 The mental model is similar to Terraform, but Kastor starts one layer earlier: the agent definition itself.
 
@@ -61,7 +61,8 @@ Implemented or prototyped today:
 
 Planned for v0:
 
-- one hosted platform provider
+- the eve (Vercel) codegen target
+- one hosted platform provider (TBD — candidates: Bedrock AgentCore, Dify)
 - a complete end-to-end weather-agent path across codegen and platform reconciliation
 - tighter first-run packaging and docs
 

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -151,7 +151,8 @@ Implemented today:
 
 Planned for v0:
 
-- a hosted platform provider
+- the eve (Vercel) codegen target
+- a hosted platform provider (TBD — candidates: Bedrock AgentCore, Dify)
 - a fully documented end-to-end hosted weather-agent example
 
 <Warning>

--- a/mintlify/reference/cli.mdx
+++ b/mintlify/reference/cli.mdx
@@ -48,6 +48,12 @@ Implemented target:
 | --- | --- |
 | `langgraph` | Implemented. Generates a Python LangGraph project. |
 
+Planned target:
+
+| Target label | Status |
+| --- | --- |
+| `eve` | Planned for v0. Vercel eve (TypeScript). Not registered in the current CLI. |
+
 There is no implemented `kastor compile` command. Use `kastor build`.
 
 ## `kastor plan`
@@ -76,7 +82,7 @@ Planned provider:
 
 | Target label | Status |
 | --- | --- |
-| `openai_assistants` | Planned for v0. Not registered in the current CLI. |
+| TBD (candidates: Bedrock AgentCore, Dify) | Planned for v0. Provider not selected; nothing registered in the current CLI. |
 
 ## `kastor apply`
 

--- a/mintlify/reference/language.mdx
+++ b/mintlify/reference/language.mdx
@@ -181,7 +181,8 @@ Target labels select implementations:
 
 - `target "langgraph"` selects the LangGraph code generator.
 - `target "memory"` selects the built-in in-memory platform provider.
-- `target "openai_assistants"` is planned, not implemented in the current provider registry.
+- `target "eve"` is planned (Vercel eve codegen), not implemented in the current CLI.
+- A hosted platform provider is planned but not yet selected (candidates: Bedrock AgentCore, Dify); no hosted target label is registered in the current provider registry.
 
 ## File discovery
 

--- a/mintlify/roadmap.mdx
+++ b/mintlify/roadmap.mdx
@@ -23,13 +23,14 @@ Kastor is early. The useful distinction is what works today, what belongs in v0,
 ## Intended v0
 
 - Parser and validation for the core language
-- One codegen target: LangGraph
-- One hosted platform provider
+- Two codegen targets: LangGraph and eve (Vercel)
+- One hosted platform provider (TBD — candidates: Bedrock AgentCore, Dify)
 - End-to-end weather-agent example
 - Clear state and drift semantics for platform reconciliation
 
 ## Planned but not implemented in the current CLI
 
+- `eve` codegen target (Vercel)
 - Hosted platform provider registration
 - `kastor init`
 - Structured `--json` rendering for diagnostics and plans


### PR DESCRIPTION
Closes #58. Sweeps all non-SPEC docs and metadata for consistency with the landscape realignment merged in #57 (SPEC.md on main is ground truth). Docs/comments only — no test semantics, no fixture renames, no CLI naming changes (that decision is now #59).

## Inventory: before → after

| Location | Before | After |
|---|---|---|
| CLAUDE.md:8 | "codegen → LangGraph first … platform reconciler → OpenAI Assistants first" | "LangGraph shipped, eve planned … provider TBD; candidates: Bedrock AgentCore, Dify" |
| CLAUDE.md:20–21 (tree) | `build/ (build/langgraph/)`, `provider/ (provider/openai/)` | `build/ (build/langgraph/, build/eve/, build/crewai/)`, `provider/ (provider/memory/; TBD — candidates: agentcore/, dify/)` — matches SPEC §6 |
| README.md "Planned for v0" | "hosted platform providers" | adds "a second codegen target: Vercel eve"; providers line reads "in design — candidates: Bedrock AgentCore, Dify" |
| README.md:212 | "Hosted platforms like OpenAI Assistants still run managed agents" | "…like Dify…" (SPEC §1's historical evidence sentence NOT duplicated — README argues reviewability/versionability, not vendor neutrality specifically) |
| cmd/kastor/platform.go:18–19 (comment) | "Issue #16 registers \"openai_assistants\" here" | "The hosted provider registers here once selected (TBD — candidates…; SPEC.md §8)" |
| internal/provider/provider.go:5 (comment) | "subpackages (provider/openai, ...)" | "subpackages (provider/memory, ...)" |
| examples/weather/kastor.hcl:19 (comment) | "Swap for a real platform target (e.g. \"openai_assistants\", issue #16)" | "…once one ships (provider TBD — candidates…; SPEC.md section 8)" |
| mintlify/AGENTS.md:29 | "Do not claim OpenAI Assistants support…" | "Do not claim support for a specific hosted platform provider; selection is TBD (candidates…). Never present OpenAI Assistants or Bedrock Agents Classic as targets — both are sunset." |
| mintlify/reference/cli.mdx | planned provider table row `openai_assistants` | row: TBD (candidates: Bedrock AgentCore, Dify); also added "Planned target" table with `eve` under `kastor build` |
| mintlify/reference/language.mdx:184 | "`target \"openai_assistants\"` is planned…" | eve planned-target bullet + "hosted platform provider planned but not yet selected (candidates…)" |
| mintlify/roadmap.mdx | "One codegen target: LangGraph", "One hosted platform provider" | "Two codegen targets: LangGraph and eve (Vercel)", provider TBD + candidates; `eve` added to planned-but-not-implemented |
| mintlify/index.mdx, quickstart.mdx | "one/a hosted platform provider", LangGraph-only pitch | eve marked planned, provider TBD + candidates |

## Deliberately untouched (with reasons)

- **Test fixtures and assertions using `openai_assistants` as an arbitrary target label** — changing fixtures risks masking regressions; the label is just an unregistered platform name to these tests:
  - `cmd/kastor/build_test.go:64,66`, `cmd/kastor/plan_test.go:223`
  - `cmd/kastor/testdata/platform_no_provider/kastor.hcl`, `cmd/kastor/testdata/build/platform_only/kastor.hcl`
  - `internal/parser/project_test.go:48,111`, `internal/parser/testdata/valid_full.hcl`, `internal/parser/testdata/invalid_platform_output.hcl`
  - `internal/state/state_test.go` + `internal/state/testdata/golden.state.json` (including `asst_123`/`asst_456` IDs — opaque strings to the state layer)
- **Model-provider OpenAI references** (`provider = "openai"` blocks, `OPENAI_API_KEY` as LLM credential in README/mintlify examples and SPEC §3.1) — OpenAI as a model provider is unaffected by the Assistants sunset.
- **SPEC.md:12 and :356** — intentional post-#57 content (historical evidence sentence; candidate list).
- **docs/superpowers/plans/2026-07-06-provider-state.md** — historical planning document, untracked in git; rewriting history would be misleading.

## gh operations performed alongside this PR

- Milestone **M-Provider (iced)** description → "On ice pending provider selection — candidates: Bedrock AgentCore, Dify. See M3." (issues and iced status untouched)

## Note: pre-existing test failure (not from this PR)

`go test ./cmd/kastor/` fails on clean main with `build_test.go:205: reported 14 files, found 7044 on disk` — the test walks the weather example's real output dir, and a local `examples/weather/gen/langgraph/.venv` inflates the count (the per-file dot-name check doesn't exclude files *inside* dot-directories). Environmental/non-hermetic test; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
