### PR TITLE
feat: support-triage canonical example — single agent, pure prompt (KAS-46)

### DIFF
--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -1,0 +1,77 @@
+# support-triage — one agent, pure prompt
+
+The smallest useful Kastor module: a single agent that classifies an inbound
+support ticket into a category, a priority, and a one-line summary. No tools,
+no orchestration — just a typed IO contract and a prompt, compiled to a
+runnable LangGraph project.
+
+| File | Purpose |
+|------|---------|
+| `kastor.hcl` | the model and the LangGraph codegen target |
+| `triage.agent` | typed inputs (`subject`, `body`, optional `customer_tier`) and outputs (`category`, `priority`, `summary`) |
+| `triage_system.prompt` | the classification rubric; requires exactly the agent's inputs |
+
+## Validate and build
+
+From the repository root:
+
+```sh
+kastor validate examples/support-triage/
+kastor build examples/support-triage/
+```
+
+Build writes a self-contained Python project to
+`examples/support-triage/gen/langgraph/` (generated output is reproducible
+and never committed).
+
+## Run the generated agent
+
+Requires Python 3.11+ and an OpenAI API key (the module's `model "fast"` is
+`openai` / `gpt-4o-mini` — swap the provider in `kastor.hcl` and rebuild to
+use another vendor).
+
+```sh
+cd examples/support-triage/gen/langgraph
+python -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+export OPENAI_API_KEY=sk-...
+python main.py triage --inputs '{
+  "subject": "Charged twice this month",
+  "body": "I upgraded to the annual plan on Friday and my card shows two charges of $228. I need one refunded before my statement closes.",
+  "customer_tier": "pro"
+}'
+```
+
+The agent returns its declared outputs as structured JSON:
+
+```json
+{
+  "category": "billing",
+  "priority": "high",
+  "summary": "Customer sees two $228 charges after upgrading to the annual plan and needs one refunded."
+}
+```
+
+`customer_tier` is optional — omit it and the prompt treats the customer as
+free tier.
+
+## See validation catch a mistake
+
+The prompt's variables and the agent's IO contract are checked against each
+other at compile time. Rename an input the prompt depends on:
+
+```sh
+sed -i '' 's/input "subject"/input "subject_line"/' examples/support-triage/triage.agent
+kastor validate examples/support-triage/
+```
+
+```
+triage.agent: agent.triage: system_prompt prompt.triage_system: variable "subject" is not an input or output of the agent
+kastor: validation failed: 1 error
+```
+
+Undo the edit (`git checkout -- examples/support-triage/triage.agent`) and
+`kastor validate` is green again — the same loop an AI writing this module
+uses to self-correct.

--- a/examples/support-triage/kastor.hcl
+++ b/examples/support-triage/kastor.hcl
@@ -1,0 +1,15 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+
+  params {
+    temperature = 0.1
+    max_tokens  = 1024
+  }
+}
+
+# Codegen target -> `kastor build` emits a runnable LangGraph project
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+}

--- a/examples/support-triage/triage.agent
+++ b/examples/support-triage/triage.agent
@@ -1,0 +1,34 @@
+agent "triage" {
+  description = "Classifies an inbound support ticket into category, priority, and a one-line summary"
+
+  model         = model.fast
+  system_prompt = prompt.triage_system
+
+  input "subject" {
+    type        = string
+    description = "Ticket subject line"
+  }
+
+  input "body" {
+    type        = string
+    description = "Full ticket body as written by the customer"
+  }
+
+  input "customer_tier" {
+    type        = string
+    optional    = true
+    description = "Customer plan tier: free, pro, or enterprise. Blank when unknown."
+  }
+
+  output "category" {
+    type = string
+  }
+
+  output "priority" {
+    type = string
+  }
+
+  output "summary" {
+    type = string
+  }
+}

--- a/examples/support-triage/triage_system.prompt
+++ b/examples/support-triage/triage_system.prompt
@@ -1,0 +1,40 @@
+---
+name     = "triage_system"
+requires = ["subject", "body", "customer_tier"]
+---
+You are a support-ticket triage assistant. Read the ticket below and produce
+three fields: category, priority, and summary. Base every judgment only on
+what the ticket says — never invent details.
+
+Ticket subject: {{subject}}
+Customer tier: {{customer_tier}}
+Ticket body:
+{{body}}
+
+## category — exactly one of
+
+- billing: charges, invoices, refunds, plan changes, payment failures
+- bug: something worked before or is documented to work, and does not
+- how-to: the product works; the customer needs guidance
+- feature-request: asks for something the product does not do
+- account: login, password, SSO, permissions, data export or deletion
+- other: none of the above fits
+
+If two fit, pick the one matching the customer's primary blocker.
+
+## priority — exactly one of
+
+- urgent: outage, data loss, security issue, or the customer cannot work at all
+- high: core feature broken with no workaround, or a paid customer blocked
+- normal: degraded but working, or a workaround exists
+- low: cosmetic issues, questions, feature requests
+
+If customer tier is enterprise, raise the priority one level (at most urgent).
+If the tier is blank, treat it as free. Never lower a priority because the
+tier is low: a free-tier outage report is still urgent.
+
+## summary
+
+One sentence, at most 120 characters, present tense, naming the actor and
+the problem — e.g. "Customer is double-charged after upgrading to annual
+billing." Do not repeat the category or priority in it.


### PR DESCRIPTION
One-agent module classifying support tickets: typed inputs (subject, body, optional customer_tier) → typed outputs (category, priority, summary). No tools, so validate/build stay fast and reproducible. README carries the exact validate/build/run commands plus a validation-error demo snippet. Generated output stays uncommitted per examples/**/gen/ gitignore rule.