### PR TITLE
feat: kastor init — new-project scaffolding (KAS-39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,11 @@ examples/**/.kastor.state.lock
 
 # MCP server connection config: can carry API keys in URLs (hosted
 # endpoints like Tavily embed the key as a query param). Must never be
-# committable by accident.
+# committable by accident. The `kastor init` scaffold's copy is the one
+# exception: it holds no credentials (local stdio server) and must be
+# tracked — go:embed bakes it into the binary.
 mcp_servers.json
+!cmd/kastor/scaffold/**/mcp_servers.json
 
 # Python artifacts from running generated projects
 **/__pycache__/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Kastor is an early proof of concept.
 
 Working today:
 
+- scaffold a new module with `kastor init`
 - parse `.agent`, `.tool`, `.prompt`, and `kastor.hcl`
 - validate references and prompt variables
 - build runnable LangGraph projects
@@ -87,6 +88,21 @@ agent "weather" {
 ```
 
 The generated code is not the source of truth. The Kastor module is.
+
+## Quickstart: start your own module
+
+`kastor init` scaffolds a minimal working module — one agent, one MCP tool, one prompt, a model, and a LangGraph codegen target — that validates and builds with zero edits:
+
+```sh
+kastor init demo
+cd demo
+kastor validate
+kastor build
+```
+
+The scaffolded agent answers a question by fetching web pages through the reference MCP fetch server (run via [`uvx`](https://docs.astral.sh/uv/), no API key needed). The scaffold's `README.md` walks through running the generated project end to end.
+
+`init` refuses a directory that already contains visible files; `--force` overwrites only the scaffold's own file names and keeps everything else.
 
 ## Quickstart: no credentials required
 

--- a/cmd/kastor/init.go
+++ b/cmd/kastor/init.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed all:scaffold
+var scaffoldFS embed.FS
+
+// scaffolds maps a --target value to its embedded scaffold directory: one
+// entry per codegen target kastor can pre-configure, mirroring the
+// generators map in build.go. eve joins when its generator ships (KAS-32) —
+// scaffolding it earlier would emit a module kastor build cannot build.
+var scaffolds = map[string]string{
+	"langgraph": "scaffold/langgraph",
+}
+
+func newInitCmd() *cobra.Command {
+	var target string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "init [--target name] [--force] [dir]",
+		Short: "Scaffold a new Kastor module",
+		Long:  "init writes a minimal working module — kastor.hcl, one agent, one MCP tool, one prompt, MCP runtime config, and a README — into dir (default: the current directory), creating it if missing. The scaffold passes kastor validate and kastor build with zero edits. A directory already holding visible files is refused unless --force, which overwrites the scaffold's own file names and leaves everything else in place.",
+		Args:  usageMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runInit(cmd.OutOrStdout(), dir, target, force)
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "langgraph", "codegen target to pre-configure (available: "+strings.Join(scaffoldNames(), ", ")+")")
+	cmd.Flags().BoolVar(&force, "force", false, "scaffold into a non-empty directory, overwriting only the scaffold's own file names")
+	return cmd
+}
+
+// runInit copies the embedded scaffold for the chosen target into dir. The
+// scaffold is static bytes baked into the binary, so the same kastor version
+// always produces a byte-identical module.
+func runInit(stdout io.Writer, dir, targetName string, force bool) error {
+	root, ok := scaffolds[targetName]
+	if !ok {
+		return usageErrorf("no scaffold for target %q (available: %s)", targetName, strings.Join(scaffoldNames(), ", "))
+	}
+
+	if !force {
+		if err := refuseNonEmpty(dir); err != nil {
+			return err
+		}
+	}
+
+	files, err := scaffoldFiles(root)
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range files {
+		data, err := scaffoldFS.ReadFile(path.Join(root, rel))
+		if err != nil {
+			return fmt.Errorf("reading embedded scaffold %s: %w", rel, err)
+		}
+		dst := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return withExitCode(2, fmt.Errorf("creating %s: %w", filepath.Dir(dst), err))
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return withExitCode(2, fmt.Errorf("writing %s: %w", dst, err))
+		}
+		fmt.Fprintf(stdout, "  created %s\n", dst)
+	}
+
+	fmt.Fprintf(stdout, "\nScaffolded a new module: %s (target %s).\n\nNext steps:\n", countNoun(len(files), "file"), targetName)
+	if dir != "." {
+		fmt.Fprintf(stdout, "  cd %s\n", dir)
+	}
+	fmt.Fprint(stdout, "  kastor validate\n  kastor build\n")
+	return nil
+}
+
+// refuseNonEmpty errors when dir already holds visible entries. Hidden
+// (dot-prefixed) entries — a .git, a .venv — belong to the user and don't
+// count, the same ownership rule build.Write applies to output directories,
+// so init works in a freshly created git repository. A missing dir is fine:
+// the write path creates it.
+func refuseNonEmpty(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return withExitCode(2, fmt.Errorf("reading %s: %w", dir, err))
+	}
+	var visible []string
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), ".") {
+			visible = append(visible, e.Name())
+		}
+	}
+	if len(visible) == 0 {
+		return nil
+	}
+	preview := strings.Join(visible[:min(len(visible), 3)], ", ")
+	if len(visible) > 3 {
+		preview += ", …"
+	}
+	return usageErrorf("%s is not empty (found %s); init needs an empty or new directory — use --force to scaffold anyway, overwriting only the scaffold's own file names", dir, preview)
+}
+
+// scaffoldFiles lists the scaffold's file paths relative to root, sorted so
+// creation output is deterministic.
+func scaffoldFiles(root string) ([]string, error) {
+	var files []string
+	err := fs.WalkDir(scaffoldFS, root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, strings.TrimPrefix(p, root+"/"))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded scaffold: %w", err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func scaffoldNames() []string {
+	names := make([]string, 0, len(scaffolds))
+	for name := range scaffolds {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/kastor/init_test.go
+++ b/cmd/kastor/init_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runCmd executes "kastor <args>" and returns combined output and the
+// execution error, mirroring runBuildCmd for arbitrary subcommands.
+func runCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err != nil {
+		fmt.Fprintf(&out, "kastor: %v\n", err)
+	}
+	return out.String(), err
+}
+
+// scaffoldFilenames is every file kastor init creates, the contract the
+// ticket names: project file, one agent, one tool, one prompt, plus the MCP
+// runtime config the tool needs and a README.
+var scaffoldFilenames = []string{
+	"kastor.hcl",
+	"researcher.agent",
+	"fetch_url.tool",
+	"researcher_system.prompt",
+	"mcp_servers.json",
+	"README.md",
+}
+
+func TestInitCommandErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, dir string) // plant preexisting state
+		args     []string                       // appended after the dir argument
+		wantCode int
+		wantOut  []string
+		skipOut  []string
+	}{
+		{
+			name: "non-empty directory is refused",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("mine\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantCode: 2,
+			wantOut:  []string{"not empty", "notes.txt", "--force"},
+			skipOut:  []string{"Scaffolded"},
+		},
+		{
+			name: "second init over a scaffold is refused",
+			setup: func(t *testing.T, dir string) {
+				if out, err := runCmd(t, "init", dir); err != nil {
+					t.Fatalf("first init failed: %v\noutput:\n%s", err, out)
+				}
+			},
+			wantCode: 2,
+			wantOut:  []string{"not empty", "--force"},
+			skipOut:  []string{"Scaffolded"},
+		},
+		{
+			name:     "eve target has no scaffold yet",
+			args:     []string{"--target", "eve"},
+			wantCode: 2,
+			wantOut:  []string{`no scaffold for target "eve"`, "langgraph"},
+			skipOut:  []string{"created"},
+		},
+		{
+			name:     "unknown target is a usage error",
+			args:     []string{"--target", "nope"},
+			wantCode: 2,
+			wantOut:  []string{`no scaffold for target "nope"`, "langgraph"},
+			skipOut:  []string{"created"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, dir)
+			}
+			out, err := runCmd(t, append([]string{"init", dir}, tt.args...)...)
+			if err == nil {
+				t.Fatalf("Execute() succeeded, want error\noutput:\n%s", out)
+			}
+			if code := exitCode(err); code != tt.wantCode {
+				t.Errorf("exit code = %d, want %d (error: %v)", code, tt.wantCode, err)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, skip := range tt.skipOut {
+				if strings.Contains(out, skip) {
+					t.Errorf("output must not contain %q:\n%s", skip, out)
+				}
+			}
+		})
+	}
+}
+
+// TestInitCommandScaffoldWorks is the ticket's acceptance path: init into a
+// new directory, then the scaffolded module must pass kastor validate and
+// kastor build with zero edits, and be in canonical kastor fmt style.
+func TestInitCommandScaffoldWorks(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "demo") // init must create missing dirs
+	out, err := runCmd(t, "init", dir)
+	if err != nil {
+		t.Fatalf("init Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "Scaffolded a new module: 6 files") {
+		t.Errorf("output missing scaffold summary:\n%s", out)
+	}
+	for _, f := range scaffoldFilenames {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("expected scaffold file %s: %v", f, err)
+		}
+	}
+
+	out, err = runCmd(t, "validate", dir)
+	if err != nil {
+		t.Fatalf("validate Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "1 agent, 1 tool, 1 prompt, 1 model, 1 target") {
+		t.Errorf("validate output missing module summary:\n%s", out)
+	}
+
+	out, err = runCmd(t, "build", dir)
+	if err != nil {
+		t.Fatalf("build Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "Built target langgraph:") {
+		t.Errorf("build output missing success line:\n%s", out)
+	}
+	for _, f := range []string{
+		filepath.Join("agents", "researcher.py"),
+		filepath.Join("tools", "fetch_url.py"),
+	} {
+		if _, err := os.Stat(filepath.Join(dir, "gen", "langgraph", f)); err != nil {
+			t.Errorf("expected generated file %s: %v", f, err)
+		}
+	}
+
+	if out, err := runCmd(t, "fmt", "--check", dir); err != nil {
+		t.Errorf("scaffold is not fmt-canonical: %v\noutput:\n%s", err, out)
+	}
+}
+
+// TestInitCommandIgnoresHiddenEntries: hidden entries belong to the user and
+// must not block a scaffold — a fresh `git init` directory is the canonical
+// case.
+func TestInitCommandIgnoresHiddenEntries(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCmd(t, "init", dir)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "kastor.hcl")); err != nil {
+		t.Errorf("expected scaffold file kastor.hcl: %v", err)
+	}
+}
+
+// TestInitCommandForce: --force scaffolds into a non-empty directory,
+// overwriting only the scaffold's own file names and keeping everything
+// else.
+func TestInitCommandForce(t *testing.T) {
+	dir := t.TempDir()
+	keep := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(keep, []byte("mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(dir, "kastor.hcl")
+	if err := os.WriteFile(stale, []byte("# stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCmd(t, "init", dir, "--force")
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+
+	if data, err := os.ReadFile(keep); err != nil || string(data) != "mine\n" {
+		t.Errorf("unrelated file must survive --force: %q, %v", data, err)
+	}
+	if data, err := os.ReadFile(stale); err != nil || strings.Contains(string(data), "# stale") {
+		t.Errorf("scaffold-named file must be overwritten by --force: %q, %v", data, err)
+	}
+}
+
+func TestInitCommandDefaultsToCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	out, err := runCmd(t, "init")
+	if err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "kastor.hcl")); err != nil {
+		t.Errorf("expected scaffold file kastor.hcl in cwd: %v", err)
+	}
+	// The dir was the cwd, so there is nothing to cd into.
+	if strings.Contains(out, "cd ") {
+		t.Errorf("next steps must not tell the user to cd into the cwd:\n%s", out)
+	}
+}
+
+// TestInitCommandDeterministic: same binary, same scaffold — byte for byte
+// (repo convention, and the ticket's "same version → same scaffold").
+func TestInitCommandDeterministic(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	for _, dir := range []string{a, b} {
+		if out, err := runCmd(t, "init", dir); err != nil {
+			t.Fatalf("init %s: %v\noutput:\n%s", dir, err, out)
+		}
+	}
+	for _, f := range scaffoldFilenames {
+		da, err := os.ReadFile(filepath.Join(a, f))
+		if err != nil {
+			t.Fatal(err)
+		}
+		db, err := os.ReadFile(filepath.Join(b, f))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(da, db) {
+			t.Errorf("%s differs between two inits", f)
+		}
+	}
+}

--- a/cmd/kastor/root.go
+++ b/cmd/kastor/root.go
@@ -27,6 +27,7 @@ func newRootCmd() *cobra.Command {
 	})
 
 	root.AddCommand(newVersionCmd())
+	root.AddCommand(newInitCmd())
 	root.AddCommand(newValidateCmd())
 	root.AddCommand(newBuildCmd())
 	root.AddCommand(newPlanCmd())

--- a/cmd/kastor/scaffold/langgraph/README.md
+++ b/cmd/kastor/scaffold/langgraph/README.md
@@ -1,0 +1,54 @@
+# Your Kastor module
+
+A starter module scaffolded by `kastor init`: one agent that answers a
+question by fetching web pages through an MCP tool. It validates and builds
+with zero edits — make it yours from there.
+
+| File | Purpose |
+|------|---------|
+| `kastor.hcl` | the model and the LangGraph codegen target |
+| `researcher.agent` | the agent: typed input (`question`), output (`answer`), tool list |
+| `fetch_url.tool` | tool interface backed by the MCP server tool `mcp://fetch/fetch` |
+| `researcher_system.prompt` | the system prompt; requires exactly the agent's inputs |
+| `mcp_servers.json` | runtime connection details for the `fetch` MCP server |
+
+## Validate and build
+
+```sh
+kastor validate
+kastor build
+```
+
+Build writes a runnable LangGraph (Python) project to `gen/langgraph/`.
+Generated output is reproducible — don't edit or commit it; edit the spec
+and rebuild.
+
+## Run the generated agent
+
+Requires Python 3.11+, [`uvx`](https://docs.astral.sh/uv/) (runs the
+reference MCP fetch server declared in `mcp_servers.json`), and an OpenAI
+API key (`model "fast"` is `openai` / `gpt-4o-mini` — swap the provider in
+`kastor.hcl` and rebuild to use another vendor).
+
+```sh
+cd gen/langgraph
+python -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+export OPENAI_API_KEY=sk-...
+export KASTOR_MCP_CONFIG=../../mcp_servers.json
+python main.py researcher --inputs '{"question": "What is HCL and who maintains it?"}'
+```
+
+The agent returns its declared outputs as structured JSON:
+
+```json
+{
+  "answer": "HCL (HashiCorp Configuration Language) is ..."
+}
+```
+
+## Next steps
+
+Quickstart and language reference: https://docs.getkastor.dev

--- a/cmd/kastor/scaffold/langgraph/fetch_url.tool
+++ b/cmd/kastor/scaffold/langgraph/fetch_url.tool
@@ -1,0 +1,19 @@
+tool "fetch_url" {
+  description = "Fetch a URL and return the page contents as markdown"
+
+  param "url" {
+    type        = string
+    description = "The absolute URL to fetch"
+  }
+
+  returns {
+    type = string
+  }
+
+  # The uri pins identity only: mcp://<server>/<tool>. How to reach the
+  # server (command, endpoint) is deployment config -- see mcp_servers.json.
+  source {
+    kind = "mcp"
+    uri  = "mcp://fetch/fetch"
+  }
+}

--- a/cmd/kastor/scaffold/langgraph/kastor.hcl
+++ b/cmd/kastor/scaffold/langgraph/kastor.hcl
@@ -1,0 +1,15 @@
+model "fast" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+
+  params {
+    temperature = 0.2
+    max_tokens  = 4096
+  }
+}
+
+# Codegen target -> `kastor build` emits a runnable LangGraph project
+target "langgraph" {
+  type   = "codegen"
+  output = "./gen/langgraph"
+}

--- a/cmd/kastor/scaffold/langgraph/mcp_servers.json
+++ b/cmd/kastor/scaffold/langgraph/mcp_servers.json
@@ -1,0 +1,7 @@
+{
+  "fetch": {
+    "transport": "stdio",
+    "command": "uvx",
+    "args": ["mcp-server-fetch"]
+  }
+}

--- a/cmd/kastor/scaffold/langgraph/researcher.agent
+++ b/cmd/kastor/scaffold/langgraph/researcher.agent
@@ -1,0 +1,17 @@
+agent "researcher" {
+  description = "Answers a question by reading web pages fetched over MCP"
+
+  model         = model.fast
+  system_prompt = prompt.researcher_system
+
+  tools = [tool.fetch_url]
+
+  input "question" {
+    type        = string
+    description = "The question to research"
+  }
+
+  output "answer" {
+    type = string
+  }
+}

--- a/cmd/kastor/scaffold/langgraph/researcher_system.prompt
+++ b/cmd/kastor/scaffold/langgraph/researcher_system.prompt
@@ -1,0 +1,11 @@
+---
+name     = "researcher_system"
+requires = ["question"]
+---
+You are a research assistant. Answer the question below.
+
+Question: {{question}}
+
+Use the fetch_url tool to read any web page you need. Prefer primary
+sources, and say so plainly when the pages you fetched do not answer the
+question. Answer concisely.

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -13,6 +13,7 @@ It validates the weather example, generates LangGraph code, and shows the platfo
 - Python 3.11\+ if you want to run generated LangGraph code
 - An OpenAI API key if you want the generated weather agent to call the configured `openai` model
 - A Tavily API key if you want to run the example MCP web-search tool against Tavily
+- [`uvx`](https://docs.astral.sh/uv/) if you want to run the MCP fetch tool in the `kastor init` scaffold
 
 <Note>
   The docs below do not assume Homebrew, npm, or another package-manager install. If a release package exists for your platform, the repository README may document it separately.
@@ -38,6 +39,29 @@ It validates the weather example, generates LangGraph code, and shows the platfo
     ```
   </Step>
 </Steps>
+
+## Scaffold your own module
+
+`kastor init` writes a minimal working module — one agent, one MCP tool, one prompt, a model, and a LangGraph codegen target:
+
+```bash
+./kastor init demo
+./kastor validate demo
+./kastor build demo
+```
+
+Expected shape:
+
+```console
+Success! Module is valid: 1 agent, 1 tool, 1 prompt, 1 model, 1 target.
+Built target langgraph: 11 files → demo/gen/langgraph
+```
+
+The scaffolded agent answers a question by fetching web pages through the reference MCP fetch server, run locally via [`uvx`](https://docs.astral.sh/uv/) — no tool API key needed. To run the generated project you need Python 3.11\+, `uvx`, and an OpenAI API key; the scaffold's `README.md` walks through it, including pointing `KASTOR_MCP_CONFIG` at the module's `mcp_servers.json`.
+
+`init` refuses a directory that already contains visible files unless you pass `--force`, and `--target` selects the pre-configured codegen target (`langgraph` today). See the [CLI reference](/reference/cli#kastor-init) for details.
+
+The rest of this quickstart uses the repository's weather example, which adds multi-agent references and the platform lifecycle.
 
 ## Validate the weather module
 

--- a/mintlify/reference/cli.mdx
+++ b/mintlify/reference/cli.mdx
@@ -11,6 +11,31 @@ kastor <command> [flags] [dir]
 
 Most commands default to the current directory when `[dir]` is omitted.
 
+## `kastor init`
+
+Scaffold a new module that passes `kastor validate` and `kastor build` with zero edits.
+
+```bash
+kastor init [--target name] [--force] [dir]
+```
+
+Example:
+
+```bash
+kastor init demo
+```
+
+The scaffold is six files: `kastor.hcl` (a model and a codegen target), one `.agent`, one `.tool`, one `.prompt`, `mcp_servers.json`, and a `README.md`. The tool binds to the reference MCP fetch server (`uvx mcp-server-fetch`, declared in `mcp_servers.json`), so the generated project runs without writing any code. Output is deterministic: the same Kastor version always produces a byte-identical scaffold.
+
+Flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--target` | Codegen target to pre-configure. Implemented: `langgraph` (default). `eve` is a usage error until its generator ships. |
+| `--force` | Scaffold into a non-empty directory. Only the scaffold's own file names are overwritten; everything else is kept. |
+
+A directory that already contains visible files is refused with exit code `2`. Hidden entries such as `.git` never block scaffolding, so `kastor init` works in a freshly created git repository.
+
 ## `kastor validate`
 
 Parse, type-check, resolve references, check prompt variables, and build the dependency graph.
@@ -139,7 +164,6 @@ kastor version
 
 | Surface | Status |
 | --- | --- |
-| `kastor init` | Listed in the design spec, not implemented in the current CLI. |
 | `--json` output | Described as a design direction for structured diagnostics and plans, not implemented in the current CLI. |
 | `kastor compile` | Not part of the current CLI. Use `kastor build`. |
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -103,13 +103,16 @@ const hclSnippet = `agent "weather" {
                   <span class="dot"></span>
                   <span class="dot"></span>
                 </div>
-                <span>examples/weather</span>
+                <span>~/kastor</span>
               </div>
-              <pre><code><span class="cmd">$ kastor validate examples/weather</span>
-ok: 3 agents, 1 tool, 2 prompts
+              <pre><code><span class="cmd">$ kastor init demo</span>
+scaffolded 6 files, ready to build
 
-<span class="cmd">$ kastor build examples/weather</span>
-wrote gen/langgraph
+<span class="cmd">$ kastor validate demo</span>
+ok: 1 agent, 1 tool, 1 prompt
+
+<span class="cmd">$ kastor build demo</span>
+wrote demo/gen/langgraph
 
 <span class="cmd">$ kastor plan examples/weather</span>
   + agent.forecast
@@ -136,6 +139,7 @@ Plan for target.memory:
               <div class="panel">
                 <h3><span class="status-dot"></span>Working today</h3>
                 <ul class="check-list">
+                  <li>scaffold a new module with <code>kastor init</code></li>
                   <li>parse <code>.agent</code>, <code>.tool</code>, <code>.prompt</code>, and <code>kastor.hcl</code></li>
                   <li>validate references and prompt variables</li>
                   <li>build runnable LangGraph projects</li>


### PR DESCRIPTION
Implements [KAS-39](https://linear.app/getkastor/issue/KAS-39/kastor-init-new-project-scaffolding): `kastor init [dir]` scaffolds a minimal working module so a new user's first five minutes don't involve hand-writing HCL from docs.

## What it does

- Scaffolds 6 files from a byte-identical embedded scaffold (`//go:embed`): `kastor.hcl` (model + langgraph codegen target), `researcher.agent`, `fetch_url.tool` (mcp source), `researcher_system.prompt`, `mcp_servers.json`, `README.md`
- The tool is runnable with zero code written: it binds to the reference MCP fetch server (`uvx mcp-server-fetch`, stdio, no API key) via the scaffolded `mcp_servers.json`
- Scaffold passes `kastor validate` and `kastor build` out of the box, and is `kastor fmt` canonical (locked by a test)
- `--target` selects the pre-configured codegen target (`scaffolds` map mirrors build.go's `generators`); `eve` is a usage error until its generator ships (KAS-32) — scaffolding it earlier would emit a module `kastor build` cannot build
- Refuses a directory with visible entries (exit 2, names the entries) unless `--force`, which overwrites only the scaffold's own file names. Hidden entries (`.git`, `.venv`) never block — same ownership rule as `build.Write`, so `git init && kastor init` works
- `.gitignore` gains an exception for the scaffold's `mcp_servers.json`: the blanket ignore exists because example configs can embed API keys in URLs, but the scaffold's copy holds no credentials and must be tracked for `go:embed`

## Acceptance (KAS-39)

`kastor init demo && cd demo && kastor validate && kastor build` succeeds with zero edits — exercised end-to-end by `TestInitCommandScaffoldWorks`, plus table-driven error tests (non-empty refusal, second-init refusal, unknown/eve target), `--force` semantics, hidden-entry tolerance, cwd default, and byte-determinism across runs. All in `t.TempDir()`, never a real example dir (KAS-35).