### PR TITLE
docs: audit the docs against the shipped code (KAS-41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,34 @@ v0 exit criteria ([KAS-36](https://linear.app/getkastor/issue/KAS-36)) are met.
   directory's `.kastorbuild` marker; a directory with no record is treated as
   the user's. Both codegen targets (langgraph, eve) are covered (KAS-24)
 
+  **Upgrade note.** `.kastorbuild` was a one-line marker and is now a versioned
+  manifest recording, per stub, the hash of what kastor last wrote and whether
+  you have edited it. An output directory built by an older kastor has no
+  records, so the first build after upgrading has no history: an untouched stub
+  is still byte-identical to the fresh one and is recognized as kastor's, but a
+  stub you implemented is treated as yours — correct, and the only direction
+  that cannot destroy your code — and arrives with one `.kastor-new` sidecar and
+  one warning, because kastor cannot tell your edits from a spec change. Diff
+  the pair, delete the sidecar; from that build on the manifest has real records
+  and it does not recur.
+
 ### Changed
 
 - v0 platform provider selected: Claude Managed Agents. `target
   "claude_agents"` is the platform target label, authenticating from
   `ANTHROPIC_API_KEY`; the provider lands in `internal/provider/claude/`.
-  Bedrock AgentCore and Dify are no longer under consideration. Spec only —
-  no provider implementation yet (KAS-37)
+  Bedrock AgentCore and Dify are no longer under consideration (KAS-37)
+- Docs audited against the shipped code (KAS-41). README, the docs site, and
+  the Mintlify authoring rules no longer describe hosted providers as planned.
+  Added: a worked `claude_agents` quickstart (module, `ANTHROPIC_API_KEY`,
+  `KASTOR_MCP_<SERVER>_URL` per MCP server, plan/apply transcript); the
+  irreversibility of `kastor destroy` on that target, which archives the agent
+  and leaves it listed in the Console forever; what the target rejects — tool
+  sources `http`, `script`, and `runtime`, model params other than `speed`, a
+  non-`anthropic` model provider — and that `input`/`output` blocks have no
+  counterpart in the remote object; and the fact that all of those are
+  apply-time errors, since `kastor validate` is target-agnostic and `plan`
+  calls no provider for a resource that is not yet in state
 
 ## [0.1.2] - 2026-07-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Kastor is "Terraform for AI agents": a declarative HCL spec compiled to agent fr
 ## What this is
 
 - Go CLI (`kastor`) that parses `.agent`, `.tool`, `.prompt`, and `kastor.hcl` project files
-- Two execution paths: `kastor build` (codegen → LangGraph and eve shipped) and `kastor plan/apply` (platform reconciler → Claude Managed Agents, selected)
+- Two execution paths: `kastor build` (codegen → LangGraph and eve shipped) and `kastor plan/apply` (platform reconciler → Claude Managed Agents and the built-in `memory` platform, both shipped)
 - Non-goals for v0: being a runtime, executing agents, eval harnesses
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Kastor is a source-of-truth layer for AI agents.**
 
-Define agents, tools, prompts, models, and targets in HCL. Validate the spec. Compile it to runnable framework code. Later, reconcile hosted agents with Terraform-style `plan` / `apply` / `state`.
+Define agents, tools, prompts, models, and targets in HCL. Validate the spec. Compile it to runnable framework code, or reconcile hosted agents with Terraform-style `plan` / `apply` / `state`.
 
 ```sh
 kastor validate examples/weather
@@ -25,12 +25,13 @@ Working today:
 - validate references and prompt variables
 - build runnable LangGraph and eve projects
 - run `kastor plan` / `kastor apply` / `kastor destroy` against the built-in in-memory platform
+- reconcile hosted [Claude Managed Agents](#quickstart-hosted-claude-agents) with `target "claude_agents"`
 - local state file, three-way diffs, and drift detection
 - examples: [weather agent](examples/weather), [content scheduler](examples/scheduler), [support triage](examples/support-triage)
 
 Planned for v0:
 
-- a hosted platform provider: Claude Managed Agents (selected, not yet implemented)
+- structured `--json` rendering for diagnostics and plans
 
 Kastor is **not** an agent runtime.
 
@@ -50,7 +51,7 @@ Kastor is **not** an agent runtime.
       ▼                   ▼
 kastor build        kastor plan/apply
 framework code      hosted agents
-(LangGraph)         (platform targets)
+(LangGraph, eve)    (Claude Managed Agents)
 ```
 
 Kastor has two paths:
@@ -126,6 +127,192 @@ Plan for target.memory: 3 to create, 0 to update, 0 to delete, 0 unchanged.
 ```
 
 `kastor plan` is a pure read: it never touches remote resources or the state file. Updates show attribute-level diffs, and out-of-band remote changes surface as drift warnings.
+
+## Quickstart: hosted Claude agents
+
+This is the hosted path: `target "claude_agents"` reconciles agents in your
+Anthropic organization through Claude Managed Agents. Unlike `memory`, `apply`
+here creates real remote objects, and `destroy` **archives them irreversibly** —
+read [Destroying a Claude agent](#destroying-a-claude-agent) before you run it.
+
+Prerequisites:
+
+- an Anthropic API key with access to Managed Agents
+- an endpoint URL for every MCP server the module's `mcp` tools name
+
+Write a module — one project file, one agent, two tools, one prompt:
+
+```hcl
+# kastor.hcl
+model "haiku" {
+  provider = "anthropic"
+  id       = "claude-haiku-4-5"
+}
+
+target "claude_agents" {
+  type = "platform"
+
+  auth {
+    api_key_env = "ANTHROPIC_API_KEY"
+  }
+}
+```
+
+```hcl
+# researcher.agent
+agent "researcher" {
+  description = "Answers research questions with web search and a hosted MCP server"
+
+  model         = model.haiku
+  system_prompt = prompt.researcher_system
+
+  tools = [tool.web_search, tool.tavily_search]
+}
+```
+
+```hcl
+# research.tool
+tool "web_search" {
+  description = "Claude's hosted web search"
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}
+
+tool "tavily_search" {
+  description = "Search the web through Tavily's hosted MCP server"
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "mcp"
+    uri  = "mcp://search-server/tavily_search"
+  }
+}
+```
+
+```text
+# researcher_system.prompt
+---
+name     = "researcher_system"
+requires = []
+---
+You are a research assistant. Answer concisely and cite your sources.
+```
+
+Two kinds of environment variable:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-YOUR-KEY
+export KASTOR_MCP_SEARCH_SERVER_URL="https://mcp.tavily.com/mcp/?tavilyApiKey=tvly-YOUR-KEY"
+```
+
+`ANTHROPIC_API_KEY` is the default credential; the `auth` block above only names
+it explicitly. Any other variable works — `api_key_env = "ANTHROPIC_API_KEY_PROD"`
+— and the `auth` block may be omitted entirely.
+
+MCP endpoints stay out of the spec, exactly as they do for codegen: the `mcp://`
+URI pins server and tool identity only. For each server named in a URI, kastor
+reads `KASTOR_MCP_<SERVER>_URL` — the server name uppercased, with every
+character outside `A-Z0-9` replaced by `_`. So `mcp://search-server/tavily_search`
+needs `KASTOR_MCP_SEARCH_SERVER_URL`. A missing one fails the apply naming the
+variable it wanted.
+
+Plan, then apply:
+
+```console
+$ kastor plan
+  + agent.researcher (not in state)
+
+Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
+
+$ kastor apply
+  + agent.researcher (not in state)
+
+Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
+
+Applied target.claude_agents: 1 created, 0 updated, 0 deleted.
+```
+
+Kastor writes the remote id to `kastor.state.json` and stamps
+`metadata.kastor_managed = "agent.researcher"` on the remote agent. That marker is
+an ownership assertion: kastor refuses to compare — and therefore to update — a
+remote agent that does not carry it, so an agent someone created in the Console
+can never be silently overwritten by an apply.
+
+Edit the spec and re-apply, and the change lands as an attribute-level update.
+Change the agent in the Console instead, and the next `plan` reports drift and
+plans the update that converges it back to the spec.
+
+### What `claude_agents` does not support
+
+The Managed Agents resource is narrower than the Kastor agent block, and Kastor
+treats fields that are meaningless for a target as errors rather than ignoring
+them (SPEC.md §3.5). On this target:
+
+| Spec | Result |
+| --- | --- |
+| `source` kind `http`, `script`, or `runtime` | Error. These are client-executed tools, and kastor is not a runtime. Wrap the implementation in an MCP server and declare it `kind = "mcp"`. |
+| `source` kind `builtin` outside the hosted toolset | Error. The hosted set is `bash`, `edit`, `glob`, `grep`, `read`, `web_fetch`, `web_search`, `write`. |
+| `model` with `provider` other than `"anthropic"` | Error. |
+| `params { temperature = ... }`, `max_tokens`, anything but `speed` | Error. The platform's model object exposes `id` and `speed` only, so `speed` is the one param that maps; omitted, it is `standard`. |
+| `input` / `output` blocks | Sent nowhere. Managed Agents has no IO-contract field; the blocks stay valid spec and still drive references and validation, but they are not part of the remote object and never appear in a diff. |
+
+These are **apply-time** errors, not validation errors — see the caveat below.
+
+### Destroying a Claude agent
+
+`kastor destroy` deletes the state entry and **archives** the remote agent.
+Archive is irreversible on this platform: the agent cannot be restored, and it
+stays listed in the Anthropic Console permanently. A later `kastor apply` does
+not resurrect it — it creates a new agent with a new id.
+
+`destroy` reads before archiving, so an agent that is already gone or already
+archived is a no-op, and an archived agent reads as absent — which is why a plan
+after destroy proposes a create rather than an update.
+
+`destroy` does not prompt for confirmation in v0. On this target, run
+`kastor plan` first and read the `-` lines.
+
+### One caveat: these errors arrive at apply, not validate
+
+`kastor validate` is target-agnostic — it parses, resolves references, and checks
+prompt variables, and it knows nothing about any provider. The table above is
+enforced by the provider, when it renders an agent for the platform.
+
+For a resource that already exists in state, that happens during `plan` (the
+provider's `Diff` is what compares it). For a resource kastor has not created
+yet, nothing calls the provider until `apply` — so `kastor plan` on a fresh
+module reports `+ agent.x (not in state)` and exits `0` even when the module can
+never apply:
+
+```console
+$ kastor plan
+  + agent.probe (not in state)
+
+Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
+
+$ kastor apply
+  + agent.probe (not in state)
+
+Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
+kastor: agent.probe: create failed (0 of 1 changes applied, state saved): tool.rest: source kind "http" cannot be mapped to Claude Managed Agents; custom tools are client-executed and kastor is not a runtime; use an MCP-server wrapper with source kind "mcp"
+```
+
+Apply stops at the first failure and state records everything applied before it,
+so a re-run plans exactly the remainder — but on this target, treat a clean plan
+as "no remote changes pending", not as "this module is valid for the platform".
 
 ## Quickstart: generate and run LangGraph
 

--- a/mintlify/AGENTS.md
+++ b/mintlify/AGENTS.md
@@ -26,7 +26,7 @@
 
 ## Content boundaries
 
-- Claude Managed Agents is the selected v0 hosted platform provider (`target "claude_agents"`), but it is not implemented yet — mark it planned, and do not document it as working. `target "memory"` is the only platform target that runs today. Never present OpenAI Assistants or Bedrock Agents Classic as targets — both are sunset.
+- Claude Managed Agents (`target "claude_agents"`) ships: `plan`, `apply`, and `destroy` all work against it. Document its real constraints rather than softening them — unsupported tool kinds and model params are errors, `destroy` archives irreversibly, and those errors surface at apply, not at `kastor validate`. `target "memory"` is still the credential-free demo platform. Never present OpenAI Assistants or Bedrock Agents Classic as targets — both are sunset.
 - Do not claim package-manager installation exists unless verified.
 - Do not document `adl.hcl` as implemented unless the parser supports it.
 - Do not document `kastor compile`; use `kastor build`.

--- a/mintlify/concepts/overview.mdx
+++ b/mintlify/concepts/overview.mdx
@@ -58,7 +58,7 @@ tool "web_search" {
 }
 ```
 
-Implemented parser support includes `mcp`, `http`, `builtin`, `runtime`, and `script` source kinds. LangGraph codegen supports `mcp`, `http`, and `runtime`; `builtin` is platform-only, and `script` glue is deferred.
+Implemented parser support includes `mcp`, `http`, `builtin`, `runtime`, and `script` source kinds. What a kind means is the target's decision: LangGraph and eve codegen support `mcp`, `http`, and `runtime`, while the `claude_agents` platform supports `mcp` and `builtin`. `script` glue is deferred everywhere. See the [source kinds table](/reference/language#tool) for the full matrix.
 
 ## Prompts
 

--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -41,7 +41,7 @@ That shape makes agent changes easier to review in pull requests and easier to r
 Kastor has two paths:
 
 - `kastor build` compiles a module into runnable framework code. LangGraph and Vercel eve are both implemented codegen targets.
-- `kastor plan` and `kastor apply` reconcile platform targets using state, diffs, and dependency ordering. The built-in `memory` provider works today for local demos and tests. Claude Managed Agents is the selected hosted provider for v0, not yet implemented.
+- `kastor plan` and `kastor apply` reconcile platform targets using state, diffs, and dependency ordering. Two providers are implemented: `claude_agents` (Claude Managed Agents, the hosted path) and the built-in `memory` provider for credential-free demos and tests.
 
 The mental model is similar to Terraform, but Kastor starts one layer earlier: the agent definition itself.
 
@@ -55,14 +55,15 @@ Implemented or prototyped today:
 - `kastor validate`
 - `kastor build` for LangGraph and eve
 - `kastor plan`, `kastor apply`, and `kastor destroy` for the built-in in-memory platform
+- `kastor plan`, `kastor apply`, and `kastor destroy` for hosted Claude Managed Agents (`target "claude_agents"`)
 - local `kastor.state.json` state for platform targets
 - canonical formatting with `kastor fmt`
 - weather, scheduler, and support-triage examples
 
 Planned for v0:
 
-- one hosted platform provider: Claude Managed Agents
 - a complete end-to-end weather-agent path across codegen and platform reconciliation
+- structured `--json` rendering for diagnostics and plans
 - tighter first-run packaging and docs
 
 ## What Kastor is not

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Quickstart"
-description: "Install kastor and run the weather example."
+description: "Install kastor, run the weather example, and reconcile a hosted Claude agent."
 ---
 
-This quickstart scaffolds a module, validates the weather example, generates LangGraph code, and shows the platform lifecycle using the built-in in-memory provider.
+This quickstart scaffolds a module, validates the weather example, generates LangGraph code, shows the platform lifecycle on the built-in in-memory provider, and then reconciles a real hosted agent with Claude Managed Agents.
 
 ## Prerequisites
 
@@ -12,6 +12,7 @@ This quickstart scaffolds a module, validates the weather example, generates Lan
 - An OpenAI API key if you want the generated weather agent to call the configured `openai` model
 - A Tavily API key if you want to run the example MCP web-search tool against Tavily
 - [`uvx`](https://docs.astral.sh/uv/) if you want to run the MCP fetch tool in the `kastor init` scaffold
+- An Anthropic API key with Managed Agents access if you want to run the hosted `claude_agents` path at the end
 
 Check the install:
 
@@ -114,7 +115,7 @@ target "memory" {
 }
 ```
 
-`memory` is implemented today. It is an in-process provider for demos, tests, and onboarding. It does not create hosted resources and does not require credentials.
+`memory` is an in-process provider for demos, tests, and onboarding. It does not create hosted resources and does not require credentials. The hosted provider is `claude_agents`, covered [below](#reconcile-a-hosted-claude-agent).
 
 ```bash
 kastor plan examples/weather
@@ -140,6 +141,124 @@ Kastor writes `kastor.state.json` in the module root. Like Terraform state, it i
 
 Because the `memory` platform is ephemeral, a later CLI invocation cannot read the previous in-memory objects. A future `plan` may report remote-missing drift and recreate them. That is expected for this provider.
 
+## Reconcile a hosted Claude agent
+
+`target "claude_agents"` reconciles agents in your Anthropic organization through Claude Managed Agents. Unlike `memory`, this creates real remote objects.
+
+<Warning>
+  `kastor destroy` **archives** a Claude agent, and archive is irreversible. The agent cannot be restored and stays listed in the Anthropic Console permanently. `destroy` does not prompt for confirmation in v0 — run `kastor plan` first and read the `-` lines.
+</Warning>
+
+### Write the module
+
+Four files in an empty directory.
+
+```hcl kastor.hcl
+model "haiku" {
+  provider = "anthropic"
+  id       = "claude-haiku-4-5"
+}
+
+target "claude_agents" {
+  type = "platform"
+
+  auth {
+    api_key_env = "ANTHROPIC_API_KEY"
+  }
+}
+```
+
+```hcl researcher.agent
+agent "researcher" {
+  description = "Answers research questions with web search and a hosted MCP server"
+
+  model         = model.haiku
+  system_prompt = prompt.researcher_system
+
+  tools = [tool.web_search, tool.tavily_search]
+}
+```
+
+```hcl research.tool
+tool "web_search" {
+  description = "Claude's hosted web search"
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}
+
+tool "tavily_search" {
+  description = "Search the web through Tavily's hosted MCP server"
+
+  param "query" {
+    type = string
+  }
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "mcp"
+    uri  = "mcp://search-server/tavily_search"
+  }
+}
+```
+
+```text researcher_system.prompt
+---
+name     = "researcher_system"
+requires = []
+---
+You are a research assistant. Answer concisely and cite your sources.
+```
+
+The model must use `provider = "anthropic"`. `tool.web_search` is `kind = "builtin"` because Claude hosts it; `tool.tavily_search` is `kind = "mcp"` because it lives on an MCP server.
+
+### Set the environment
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-YOUR-KEY
+export KASTOR_MCP_SEARCH_SERVER_URL="https://mcp.tavily.com/mcp/?tavilyApiKey=tvly-YOUR-KEY"
+```
+
+`ANTHROPIC_API_KEY` is the default credential. The `auth` block above only names it explicitly; you can point `api_key_env` at any other variable, or omit `auth` entirely.
+
+MCP endpoints are deployment configuration, never spec — the `mcp://` URI pins server and tool identity only. For each server a URI names, kastor reads `KASTOR_MCP_<SERVER>_URL`: the server name uppercased, with every character outside `A-Z0-9` replaced by `_`. So `mcp://search-server/tavily_search` needs `KASTOR_MCP_SEARCH_SERVER_URL`. A missing one fails the apply and names the variable it wanted.
+
+### Plan and apply
+
+```bash
+kastor plan
+kastor apply
+```
+
+```console
+$ kastor apply
+  + agent.researcher (not in state)
+
+Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
+
+Applied target.claude_agents: 1 created, 0 updated, 0 deleted.
+```
+
+Kastor records the remote id in `kastor.state.json` and stamps `metadata.kastor_managed = "agent.researcher"` on the remote agent. That marker is an ownership assertion: kastor refuses to compare — and therefore to update — a remote agent that does not carry it, so an agent created by hand in the Console cannot be silently overwritten.
+
+Edit the spec and re-apply, and the change lands as an attribute-level update. Change the agent in the Console instead, and the next `plan` reports drift and plans the update that converges it back.
+
+### Know the constraints before you apply
+
+The Managed Agents resource is narrower than the Kastor agent block, and Kastor treats fields that are meaningless for a target as errors rather than ignoring them. Tool kinds `http`, `script`, and `runtime` are rejected, model `params` other than `speed` are rejected, and `input` / `output` blocks are not part of the remote object at all. See [platform providers](/reference/cli#platform-providers) for the full table.
+
+<Warning>
+  These are apply-time errors. `kastor validate` is target-agnostic, and `kastor plan` on a module it has not created yet calls no provider — so a plan can be clean and exit `0` for a module that can never apply. Read a clean plan as "no remote changes pending", not "valid for this platform".
+</Warning>
+
 ## Intended v0 workflow
 
 The intended workflow is:
@@ -155,12 +274,12 @@ Implemented today:
 
 - `validate`
 - `build` for LangGraph and eve
-- `plan` / `apply` / `destroy` for `target "memory"`
+- `plan` / `apply` / `destroy` for `target "memory"` and `target "claude_agents"`
 
 Planned for v0:
 
-- a hosted platform provider: Claude Managed Agents
 - a fully documented end-to-end hosted weather-agent example
+- structured `--json` rendering for diagnostics and plans
 
 <Warning>
   There is no implemented `kastor compile` command. The current compiler command is `kastor build`.

--- a/mintlify/reference/cli.mdx
+++ b/mintlify/reference/cli.mdx
@@ -196,9 +196,32 @@ These warnings go to stderr and do **not** fail the build: the code was
 generated and synced, so `kastor build` still exits `0`.
 
 Ownership is tracked in the `.kastorbuild` marker at the root of the output
-directory. Deleting it is safe but forgetful — with no record, kastor can no
-longer tell its own untouched stub from your implementation, so it treats every
-existing file as yours.
+directory. Deleting it is safe but forgetful: with no records, kastor can no
+longer tell which stub you last saw, so any file that is not byte-identical to
+the stub it would generate today counts as yours. That is the direction that
+cannot lose your work; the cost is one spurious sidecar per implemented stub.
+
+#### Upgrading from a pre-manifest build
+
+`.kastorbuild` used to be a one-line marker: proof that kastor owned the
+directory, and nothing more. It is now a versioned manifest that also records,
+per preserve-mode file, the SHA-256 of the stub kastor last wrote there and
+whether you have since edited it.
+
+An output directory built by an older kastor has a marker with no records, so
+the first build after upgrading has no history to consult:
+
+| File in that directory | First build after upgrading |
+| --- | --- |
+| An untouched stub | Still byte-identical to the freshly generated stub, so kastor recognizes it as its own. Nothing happens. |
+| A stub you implemented | Treated as yours and left alone — correct, and the only direction that cannot destroy your code. But with no record of the stub you last saw, kastor cannot tell your edits from a spec change, so it writes a `<name>.kastor-new` sidecar and reports it once. |
+
+For that second row, diff the pair, confirm the interface has not actually moved
+under you, and delete the sidecar. The manifest is written with real records from
+that build onward, so it happens exactly once per implemented stub.
+
+A marker written by a *newer* kastor than the one you are running is a hard
+error rather than a guess — upgrade, or build into a different directory.
 
 ## `kastor plan`
 
@@ -214,19 +237,18 @@ Example:
 kastor plan examples/weather
 ```
 
-`plan` is a pure read. It should not modify remote resources or write the state file.
+`plan` is a pure read. It only issues the provider's `Read` and `Diff` calls, and it never writes the state file.
 
-Implemented provider:
+Implemented providers:
 
 | Target label | Status |
 | --- | --- |
+| `claude_agents` | Implemented. Claude Managed Agents, the hosted provider. See [platform providers](#platform-providers). |
 | `memory` | Implemented. Ephemeral in-memory provider for local demos and tests. |
 
-Planned provider:
-
-| Target label | Status |
-| --- | --- |
-| `claude_agents` | Planned for v0. Claude Managed Agents is the selected provider; nothing registered in the current CLI yet. |
+<Warning>
+  A clean plan is not a validity check. For a resource kastor has not created yet there is no remote object to read and nothing calls the provider, so provider-level errors — an unsupported tool kind, an unsupported model param — do not appear until `kastor apply`.
+</Warning>
 
 ## `kastor apply`
 
@@ -252,7 +274,57 @@ Delete all resources tracked in state for selected platform targets.
 kastor destroy [--target name] [dir]
 ```
 
-`destroy` deletes resources in reverse dependency order and updates state after each deletion.
+`destroy` deletes resources in reverse dependency order and updates state after each deletion. It does not prompt for confirmation in v0.
+
+<Warning>
+  On `target "claude_agents"`, delete means **archive**, and archive is irreversible. The agent cannot be restored and stays listed in the Anthropic Console permanently. A later `kastor apply` does not resurrect it — it creates a new agent with a new id. Run `kastor plan` first and read the `-` lines.
+</Warning>
+
+## Platform providers
+
+A platform target's label selects its provider. Two are registered.
+
+### `memory`
+
+The built-in in-memory platform: an ephemeral store so `plan` / `apply` / `destroy` can be exercised with no credentials and no network. `auth` on it is an error. Its remote objects die with the process, so a later invocation truthfully reports previously applied resources as remote-missing drift.
+
+### `claude_agents`
+
+Claude Managed Agents. Each `agent` block becomes one hosted agent; its model, system prompt, and tools are folded into that one remote object.
+
+Credentials come from `ANTHROPIC_API_KEY` by default. An `auth` block renames the variable:
+
+```hcl
+target "claude_agents" {
+  type = "platform"
+
+  auth {
+    api_key_env = "ANTHROPIC_API_KEY_PROD"
+  }
+}
+```
+
+Every MCP server named by a tool's `mcp://<server>/<tool>` URI needs an endpoint URL in the environment, under `KASTOR_MCP_<SERVER>_URL` — the server name uppercased, with every character outside `A-Z0-9` replaced by `_`. `mcp://search-server/tavily_search` reads `KASTOR_MCP_SEARCH_SERVER_URL`.
+
+Kastor stamps `metadata.kastor_managed = "<block address>"` on every agent it creates and refuses to compare a remote agent that does not carry the marker, so an agent created by hand in the Console cannot be overwritten by an apply.
+
+The Managed Agents resource is narrower than the Kastor agent block, and fields that are meaningless for a target are errors rather than silently ignored:
+
+| Spec | Result on `claude_agents` |
+| --- | --- |
+| `source { kind = "mcp" }` | Supported. Becomes an `mcp_toolset` entry plus an `mcp_servers` URL entry. |
+| `source { kind = "builtin" }` | Supported for the hosted toolset: `bash`, `edit`, `glob`, `grep`, `read`, `web_fetch`, `web_search`, `write`. Any other name is an error. |
+| `source` kind `http`, `script`, or `runtime` | Error. These are client-executed tools and kastor is not a runtime. Wrap the implementation in an MCP server and declare it `kind = "mcp"`. |
+| `model` with `provider` other than `"anthropic"` | Error. |
+| `params { speed = ... }` | Supported. Omitted, the platform model speed is `standard`. |
+| `params { temperature = ... }`, `max_tokens`, any other key | Error. The platform's model object exposes `id` and `speed` only. |
+| `input` / `output` blocks | Not sent. Managed Agents has no IO-contract field. The blocks stay valid spec and still drive references and validation, but they are not part of the remote object and never appear in a diff. |
+
+<Warning>
+  Every row above is enforced by the provider, not by `kastor validate` — which is target-agnostic and knows nothing about any provider. For a resource already in state the check runs during `plan`; for one kastor has not created yet, nothing calls the provider until `apply`.
+</Warning>
+
+Failures are classified: authentication (`401`/`403`, naming the env var to check), not-found, out-of-band update conflict (`409`, telling you to re-run `kastor plan`), and transient (`429`/`5xx`), which is retried to a total of three attempts, honoring `Retry-After`. Apply stops at the first failure with everything applied up to that point already saved in state, so a re-run plans exactly the remainder.
 
 ## `kastor fmt`
 

--- a/mintlify/reference/language.mdx
+++ b/mintlify/reference/language.mdx
@@ -100,15 +100,15 @@ Rules:
 - Parameter defaults must be literals of the declared type.
 - `default = null` is invalid. Omit the attribute instead.
 
-Source kinds:
+Source kinds. Every kind parses; what a kind means is decided by the target that consumes it.
 
-| Kind | Current behavior |
-| --- | --- |
-| `mcp` | Parsed and supported by LangGraph codegen through generated MCP bindings. |
-| `http` | Parsed and supported by LangGraph codegen as a POST wrapper. |
-| `runtime` | Parsed and supported by LangGraph codegen as a stub for user code. The stub is generated once: after you edit it, later builds keep your file, and a spec change arrives as a `<name>.kastor-new` sidecar to reconcile. |
-| `builtin` | Parsed for platform targets; not valid for local LangGraph codegen. |
-| `script` | Parsed, but LangGraph execution glue is deferred. |
+| Kind | LangGraph codegen | `claude_agents` platform |
+| --- | --- | --- |
+| `mcp` | Generated MCP binding. | Supported: an `mcp_toolset` entry plus an endpoint from `KASTOR_MCP_<SERVER>_URL`. |
+| `http` | POST wrapper. | Error — wrap it in an MCP server instead. |
+| `runtime` | Stub for user code. The stub is generated once: after you edit it, later builds keep your file, and a spec change arrives as a `<name>.kastor-new` sidecar to reconcile. | Error — wrap it in an MCP server instead. |
+| `builtin` | Codegen error, permanently: a platform-provided tool has no local binding. | Supported for the hosted toolset (`bash`, `edit`, `glob`, `grep`, `read`, `web_fetch`, `web_search`, `write`). |
+| `script` | Codegen error for now; execution glue is deferred. | Error — wrap it in an MCP server instead. |
 
 ## `.prompt`
 
@@ -167,7 +167,7 @@ target "memory" {
 | --- | --- | --- |
 | `provider` | required | Provider name such as `openai`, `anthropic`, `google`, or `ollama`. |
 | `id` | required | Provider model identifier. |
-| `params` | optional | Provider-specific key/value bag. |
+| `params` | optional | Provider-specific key/value bag. Keys are not checked at parse time — the consuming target validates them. LangGraph codegen requires valid Python keyword arguments; `claude_agents` accepts `speed` and rejects everything else, including `temperature` and `max_tokens`. |
 
 `target` fields:
 
@@ -180,9 +180,11 @@ target "memory" {
 Target labels select implementations:
 
 - `target "langgraph"` selects the LangGraph code generator.
-- `target "memory"` selects the built-in in-memory platform provider.
 - `target "eve"` selects the Vercel eve code generator.
-- `target "claude_agents"` is planned (Claude Managed Agents); it is not registered in the current provider registry.
+- `target "memory"` selects the built-in in-memory platform provider.
+- `target "claude_agents"` selects the Claude Managed Agents provider. Its `auth` block defaults to `api_key_env = "ANTHROPIC_API_KEY"`; see [platform providers](/reference/cli#platform-providers) for what it does and does not accept.
+
+A label with no registered generator or provider is an error naming the ones that exist.
 
 ## File discovery
 

--- a/mintlify/roadmap.mdx
+++ b/mintlify/roadmap.mdx
@@ -17,6 +17,7 @@ Kastor is early. The useful distinction is what works today, what belongs in v0,
 - `kastor build` for LangGraph and eve
 - `kastor plan`, `kastor apply`, and `kastor destroy`
 - Built-in `memory` platform provider
+- Claude Managed Agents platform provider (`target "claude_agents"`)
 - Local `kastor.state.json`
 - `kastor fmt`
 - `kastor version`
@@ -32,9 +33,14 @@ Kastor is early. The useful distinction is what works today, what belongs in v0,
 
 ## Planned but not implemented in the current CLI
 
-- Hosted platform provider registration (Claude Managed Agents)
 - A scaffold for `kastor init --target eve`
 - Structured `--json` rendering for diagnostics and plans
+
+## Known gaps
+
+- Provider constraints are not checked by `kastor validate`. It is target-agnostic, so a module that no platform provider can accept still validates. On `claude_agents`, an unsupported tool kind or model param surfaces at `apply` — or at `plan` only once the resource exists in state. See [platform providers](/reference/cli#platform-providers).
+- The weather example runs on codegen and the `memory` platform, not on `claude_agents`: its model uses `provider = "openai"`, which the hosted provider rejects.
+- An agent's `input` and `output` blocks have no counterpart in the Claude Managed Agents resource, so they are not reconciled to that target.
 
 ## Deferred v1 ideas
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -142,16 +142,18 @@ Plan for target.memory:
                   <li>scaffold a new module with <code>kastor init</code></li>
                   <li>parse <code>.agent</code>, <code>.tool</code>, <code>.prompt</code>, and <code>kastor.hcl</code></li>
                   <li>validate references and prompt variables</li>
-                  <li>build runnable LangGraph projects</li>
+                  <li>build runnable LangGraph and eve projects</li>
                   <li>run <code>kastor plan</code> / <code>kastor apply</code> / <code>kastor destroy</code> against the built-in in-memory platform</li>
+                  <li>reconcile hosted Claude Managed Agents with <code>target "claude_agents"</code></li>
                   <li>local state file, three-way diffs, and drift detection</li>
-                  <li>examples: weather agent and content scheduler</li>
+                  <li>examples: weather agent, content scheduler, and support triage</li>
                 </ul>
               </div>
               <div class="panel">
                 <h3><span class="status-dot planned"></span>Planned</h3>
                 <ul class="check-list">
-                  <li>hosted platform providers</li>
+                  <li>structured <code>--json</code> diagnostics and plans</li>
+                  <li>more hosted platform providers</li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
A truth pass over `README.md` and `mintlify/` (plus the landing page and `CLAUDE.md`) now that the Claude Managed Agents provider (KAS-38) and the build preserve contract (KAS-24) have merged. No behavior changes — docs only.

## What changed

**`claude_agents` ships.** Every status surface still listed hosted providers as planned for v0. README, `mintlify/index.mdx`, `roadmap.mdx`, `reference/cli.mdx`, `reference/language.mdx`, `site/src/pages/index.astro`, and `CLAUDE.md` now say it works. `mintlify/AGENTS.md` no longer instructs future doc work to mark it planned.

**A real plan/apply quickstart.** The old one covered only the `memory` provider, which needs no credentials and creates nothing. Added the hosted path in both the README and the mintlify quickstart: a four-file module, `ANTHROPIC_API_KEY` (or whatever `auth.api_key_env` names), and `KASTOR_MCP_<SERVER>_URL` per MCP server with the name-derivation rule spelled out. The `validate` / `fmt --check` / `plan` output in the docs was run against that exact module; the `apply` transcript uses the strings the acceptance test asserts against the live API.

**`destroy` archives, irreversibly.** Called out in both quickstarts and in the CLI reference's `destroy` section, alongside the fact that `destroy` does not prompt in v0.

**What the target rejects**, as a table in the README and in a new `## Platform providers` section of the CLI reference: tool sources `http` / `script` / `runtime` (with the MCP-wrapper workaround), `builtin` outside the hosted toolset, a non-`anthropic` model provider, and every model `params` key but `speed`.

**`.kastorbuild` upgrade note** in the CLI reference and the changelog.

## One correction to the brief

The unsupported tool kinds and model params are **apply-time** errors, not validate-time. `kastor validate` is target-agnostic, and `BuildPlan` calls no provider for a resource that is not in state yet — so `kastor plan` on a fresh module exits `0` for a module that can never apply:

```console
$ kastor plan
  + agent.probe (not in state)

Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.

$ kastor apply
kastor: agent.probe: create failed (0 of 1 changes applied, state saved): tool.rest: source kind "http" cannot be mapped to Claude Managed Agents; ...
```

Documented as the caveat it is in all three places rather than softened.

## Two other gaps found

- An agent's `input` / `output` blocks are **not sent** to `claude_agents` — `normalizeSpec` omits them deliberately, since Managed Agents has no IO-contract field. Was undocumented; now stated in the constraint tables and the roadmap's new Known gaps section.
- The weather example cannot run on `claude_agents` (`provider = "openai"`), so the SPEC §8 milestone "the weather agent end-to-end on both paths" is not met. Listed under Known gaps and kept in "Planned for v0" rather than quietly dropped.

`CHANGELOG.md`'s `[Unreleased]` heading structure is untouched.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` all packages pass. Every command transcript in the changed docs was executed.