### PR TITLE
fix: catch unappliable specs at plan, not apply (KAS-55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ v0 exit criteria ([KAS-36](https://linear.app/getkastor/issue/KAS-36)) are met.
 
 ### Fixed
 
+- `kastor plan` no longer green-lights a module the target cannot apply. A
+  resource absent from state never reached the provider, so a spec with an
+  unsupported tool source kind, a non-anthropic model provider, an unsupported
+  model param, or a missing `KASTOR_MCP_<SERVER>_URL` planned clean as
+  `+ agent.x (not in state)` and exited 0, then failed part-way through apply.
+  Planned creates are now validated through the provider's `Diff` against an
+  absent remote and fail the plan naming the resource and the target. The
+  provider contract states what `Diff` must do when the remote object does not
+  exist; `kastor validate` itself stays provider-agnostic (KAS-55)
+
 - `kastor build` no longer overwrites an implemented `runtime` tool stub. Such
   a stub is generated once and then belongs to the user: the file is written
   only while it still matches the stub the last build wrote, is kept rather

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ MCP endpoints stay out of the spec, exactly as they do for codegen: the `mcp://`
 URI pins server and tool identity only. For each server named in a URI, kastor
 reads `KASTOR_MCP_<SERVER>_URL` — the server name uppercased, with every
 character outside `A-Z0-9` replaced by `_`. So `mcp://search-server/tavily_search`
-needs `KASTOR_MCP_SEARCH_SERVER_URL`. A missing one fails the apply naming the
+needs `KASTOR_MCP_SEARCH_SERVER_URL`. A missing one fails the plan naming the
 variable it wanted.
 
 Plan, then apply:
@@ -269,7 +269,7 @@ them (SPEC.md §3.5). On this target:
 | `params { temperature = ... }`, `max_tokens`, anything but `speed` | Error. The platform's model object exposes `id` and `speed` only, so `speed` is the one param that maps; omitted, it is `standard`. |
 | `input` / `output` blocks | Sent nowhere. Managed Agents has no IO-contract field; the blocks stay valid spec and still drive references and validation, but they are not part of the remote object and never appear in a diff. |
 
-These are **apply-time** errors, not validation errors — see the caveat below.
+These are **plan-time** errors, not validation errors — see the caveat below.
 
 ### Destroying a Claude agent
 
@@ -285,34 +285,32 @@ after destroy proposes a create rather than an update.
 `destroy` does not prompt for confirmation in v0. On this target, run
 `kastor plan` first and read the `-` lines.
 
-### One caveat: these errors arrive at apply, not validate
+### One caveat: these errors arrive at plan, not validate
 
 `kastor validate` is target-agnostic — it parses, resolves references, and checks
 prompt variables, and it knows nothing about any provider. The table above is
 enforced by the provider, when it renders an agent for the platform.
 
-For a resource that already exists in state, that happens during `plan` (the
-provider's `Diff` is what compares it). For a resource kastor has not created
-yet, nothing calls the provider until `apply` — so `kastor plan` on a fresh
-module reports `+ agent.x (not in state)` and exits `0` even when the module can
-never apply:
+That rendering happens during `plan`, for every resource — including one kastor
+has not created yet, where there is no remote object to compare against. So a
+module that could never apply fails the plan, naming the resource and the target:
 
 ```console
+$ kastor validate
+Success! Module is valid: 1 agent, 1 tool, 1 prompt, 1 model, 1 target.
+
 $ kastor plan
-  + agent.probe (not in state)
+kastor: agent.probe: cannot be created on target.claude_agents: tool.rest: source kind "http" cannot be mapped to Claude Managed Agents; custom tools are client-executed and kastor is not a runtime; use an MCP-server wrapper with source kind "mcp"
 
-Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
-
-$ kastor apply
-  + agent.probe (not in state)
-
-Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.
-kastor: agent.probe: create failed (0 of 1 changes applied, state saved): tool.rest: source kind "http" cannot be mapped to Claude Managed Agents; custom tools are client-executed and kastor is not a runtime; use an MCP-server wrapper with source kind "mcp"
+$ echo $?
+1
 ```
 
-Apply stops at the first failure and state records everything applied before it,
-so a re-run plans exactly the remainder — but on this target, treat a clean plan
-as "no remote changes pending", not as "this module is valid for the platform".
+A clean plan therefore does mean "this module maps onto this target". What it
+still cannot promise is that the platform will accept it — credentials, quotas,
+and model availability are only known to the API. When one of those fails, apply
+stops at the first failure and state records everything applied before it, so a
+re-run plans exactly the remainder.
 
 ## Quickstart: generate and run LangGraph
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -296,6 +296,8 @@ Per resource, in the module's topological order (deletes first, in reverse depen
 | in spec and state, remote matches | no-op |
 | in state, not in spec | delete ("removed from spec") |
 
+**Creates are validated, not assumed:** for every planned create the engine calls the provider's `Diff` against an absent remote (§6), so a spec the target cannot express — an unsupported tool source kind, a foreign model provider — is a plan error naming the resource, not an apply-time surprise.
+
 **Drift** (remote changed outside kastor) is detected by diffing the *last-applied* config against the remote and reported as a warning naming the changed attributes; apply converges the remote back to the spec. When the user instead edits the spec to match a manual remote change, the plan is a no-op and apply silently refreshes the stale state entry (no remote call), so the warning does not recur.
 
 **Plan output.** One line per pending change, in execution order: `+` create, `~` update, `-` delete, with the reason in parentheses on creates and deletes, and one indented `path: old → new` line per attribute diff under updates (values render as compact JSON, truncated so a prompt body cannot flood the plan). An attribute diff is `{path, old, new}` with dotted paths (`model.id`, `tools[0].source.uri`); `old` is null when an attribute is being added, `new` null when it is being removed. Warnings precede the summary. The summary line is countable and per-target — `Plan for target.<name>: N to create, M to update, K to delete, J unchanged.` — or `No changes for target.<name>: remote matches the spec (N resources).` when nothing is pending. The whole plan (target, ordered changes, attribute diffs, diagnostics) is one serializable tree, so the `--json` rendering (§9) is a second renderer over the same data, not a second pipeline.
@@ -333,6 +335,7 @@ Providers implement a common interface (`Read/Create/Update/Delete/Diff`) — la
 - `Create(resource)` returns the platform's id; the engine records it in state immediately.
 - `Delete(id)` is idempotent: deleting an already-missing remote object succeeds, so re-runs after partial failures converge.
 - `Diff(desired, remote)` is the comparison authority — only the provider knows how the neutral config maps onto its platform's attributes. Empty result = in sync. The engine also diffs the last-applied config against the remote for drift detection.
+- `Diff` must accept a **nil remote**, meaning the object does not exist on the platform. It then validates the desired config exactly as it would against an existing object — returning an error is how a provider rejects a spec it cannot map — and otherwise returns one attribute diff per attribute a `Create` would set. The engine calls `Diff` this way for every planned create, so a module that cannot apply fails at plan.
 - `Diff` must be pure and deterministic; `Read` must not mutate. `kastor plan` issues only these two.
 
 The plan/apply engine is target-agnostic and consumes exactly what `kastor validate` assembles (loaded module, dependency graph, topological order) plus the state file — the same shape as the codegen engine's `Generate(job)` contract.

--- a/cmd/kastor/plan_test.go
+++ b/cmd/kastor/plan_test.go
@@ -185,6 +185,131 @@ func TestPlanWeatherExample(t *testing.T) {
 	}
 }
 
+// TestPlanRejectsUnappliableClaudeModule is the KAS-55 regression: a module
+// the Claude Managed Agents target cannot express must fail at plan, not at
+// apply. Nothing reaches the network — the agent is absent from state, so
+// plan only renders the spec through the provider.
+func TestPlanRejectsUnappliableClaudeModule(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		body    string
+		wantOut []string
+	}{
+		{
+			name: "unsupported tool source kind",
+			file: "probe.tool",
+			body: `tool "read" {
+  description = "Read a record over HTTP"
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "http"
+    uri  = "https://api.example.com/records"
+  }
+}
+`,
+			wantOut: []string{"agent.probe", "tool.read", `source kind "http"`, "MCP-server wrapper"},
+		},
+		{
+			name: "non-anthropic model provider",
+			file: "kastor.hcl",
+			body: `model "haiku" {
+  provider = "openai"
+  id       = "gpt-4o-mini"
+}
+
+target "claude_agents" {
+  type = "platform"
+
+  auth {
+    api_key_env = "ANTHROPIC_API_KEY"
+  }
+}
+`,
+			wantOut: []string{"agent.probe", "model.provider", "openai", "anthropic"},
+		},
+		{
+			name: "unsupported model param",
+			file: "kastor.hcl",
+			body: `model "haiku" {
+  provider = "anthropic"
+  id       = "claude-haiku-4-5"
+
+  params {
+    temperature = 0.2
+  }
+}
+
+target "claude_agents" {
+  type = "platform"
+
+  auth {
+    api_key_env = "ANTHROPIC_API_KEY"
+  }
+}
+`,
+			wantOut: []string{"agent.probe", "model.params.temperature", "unsupported", "speed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ANTHROPIC_API_KEY", "plan-does-not-call-the-api")
+			dir := copyModule(t, "testdata/claude_plan")
+			if err := os.WriteFile(filepath.Join(dir, tt.file), []byte(tt.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			// The module itself is well-formed: kastor validate is
+			// provider-agnostic and must still pass.
+			if out, err := runCLI(t, "validate", dir); err != nil {
+				t.Fatalf("validate rejected a well-formed module: %v\n%s", err, out)
+			}
+
+			out, err := runCLI(t, "plan", dir)
+			if err == nil {
+				t.Fatalf("plan succeeded on a module that cannot apply\noutput:\n%s", out)
+			}
+			if code := exitCode(err); code != 1 {
+				t.Errorf("exit code = %d, want 1 (error: %v)", code, err)
+			}
+			for _, want := range append(tt.wantOut, "target.claude_agents") {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(dir, state.Filename)); !os.IsNotExist(err) {
+				t.Error("a failed plan wrote a state file")
+			}
+		})
+	}
+}
+
+// TestPlanValidClaudeModuleStillPlansACreate is the happy-path counterpart:
+// plan-time provider validation must not reject a module the target can
+// express.
+func TestPlanValidClaudeModuleStillPlansACreate(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "plan-does-not-call-the-api")
+	dir := copyModule(t, "testdata/claude_plan")
+
+	out, err := runCLI(t, "plan", dir)
+	if err != nil {
+		t.Fatalf("plan: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"+ agent.probe (not in state)",
+		"Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestPlatformCommandErrors(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/kastor/testdata/claude_plan/kastor.hcl
+++ b/cmd/kastor/testdata/claude_plan/kastor.hcl
@@ -1,0 +1,12 @@
+model "haiku" {
+  provider = "anthropic"
+  id       = "claude-haiku-4-5"
+}
+
+target "claude_agents" {
+  type = "platform"
+
+  auth {
+    api_key_env = "ANTHROPIC_API_KEY"
+  }
+}

--- a/cmd/kastor/testdata/claude_plan/probe.agent
+++ b/cmd/kastor/testdata/claude_plan/probe.agent
@@ -1,0 +1,7 @@
+agent "probe" {
+  description = "Plan-time provider validation fixture (KAS-41)"
+
+  model         = model.haiku
+  system_prompt = prompt.probe_system
+  tools         = [tool.read]
+}

--- a/cmd/kastor/testdata/claude_plan/probe.prompt
+++ b/cmd/kastor/testdata/claude_plan/probe.prompt
@@ -1,0 +1,5 @@
+---
+name = "probe_system"
+requires = []
+---
+You are a Kastor plan-validation fixture. Do nothing interesting.

--- a/cmd/kastor/testdata/claude_plan/probe.tool
+++ b/cmd/kastor/testdata/claude_plan/probe.tool
@@ -1,0 +1,11 @@
+tool "read" {
+  description = "Read a file from the managed agent workspace"
+
+  returns {
+    type = string
+  }
+
+  source {
+    kind = "builtin"
+  }
+}

--- a/internal/provider/apply_test.go
+++ b/internal/provider/apply_test.go
@@ -22,12 +22,16 @@ func countingSave(n *int) func() error {
 	}
 }
 
+// buildPlan plans against the fake and resets its call log, so the call
+// assertions in this file cover the apply under test and not the read/diff
+// calls the planning phase made first.
 func buildPlan(t *testing.T, fake *providertest.Fake, job *provider.Job) *provider.Plan {
 	t.Helper()
 	plan, err := provider.BuildPlan(context.Background(), fake, job)
 	if err != nil {
 		t.Fatalf("BuildPlan: %v", err)
 	}
+	fake.Calls = nil
 	return plan
 }
 

--- a/internal/provider/claude/diff.go
+++ b/internal/provider/claude/diff.go
@@ -66,8 +66,18 @@ func diffMap(path string, desired, remote map[string]any, out *[]provider.AttrDi
 		}
 		switch {
 		case !inRemote:
+			// An absent key and an explicit null are the same state, so a
+			// null desired value is not an addition. This is what keeps the
+			// create path (remote is the empty object) from reporting every
+			// unset optional field as an attribute it will set.
+			if want == nil {
+				continue
+			}
 			*out = append(*out, provider.AttrDiff{Path: subpath, Old: nil, New: want})
 		case !inDesired:
+			if got == nil {
+				continue
+			}
 			*out = append(*out, provider.AttrDiff{Path: subpath, Old: got, New: nil})
 		default:
 			diffValue(subpath, want, got, out)

--- a/internal/provider/claude/normalize.go
+++ b/internal/provider/claude/normalize.go
@@ -48,10 +48,19 @@ type normalizationRules struct {
 
 // normalizeForDiff returns two independent comparison objects with all
 // provider-injected and provider-owned fields handled.
+//
+// A nil remote is the create path: the spec is still normalized in full —
+// that is what rejects a config Managed Agents cannot express — and compared
+// against an empty object, so every attribute reads as an addition. There is
+// no marker to assert, because Create is what stamps it.
 func normalizeForDiff(desired *provider.Resource, remote provider.Object) (provider.Object, provider.Object, error) {
 	spec, rules, err := normalizeDesired(desired)
 	if err != nil {
 		return nil, nil, err
+	}
+	if remote == nil {
+		delete(spec["metadata"].(map[string]any), managedMarkerKey)
+		return spec, provider.Object{}, nil
 	}
 	echo, err := normalizeAPIEcho(remote, rules)
 	if err != nil {

--- a/internal/provider/claude/normalize_test.go
+++ b/internal/provider/claude/normalize_test.go
@@ -253,6 +253,82 @@ func TestMappingValidationErrors(t *testing.T) {
 	}
 }
 
+// TestDiffCreatePathValidatesTheSpec is the KAS-55 contract: a nil remote is
+// how the engine asks "could this be created?", so every mapping error must
+// surface there instead of waiting for apply.
+func TestDiffCreatePathValidatesTheSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(provider.Object)
+		wantErr []string
+	}{
+		{
+			name: "non-anthropic model provider",
+			mutate: func(cfg provider.Object) {
+				cfg["model"].(map[string]any)["provider"] = "openai"
+			},
+			wantErr: []string{"agent.weather", "model.provider", "openai", "anthropic"},
+		},
+		{
+			name: "unsupported model param",
+			mutate: func(cfg provider.Object) {
+				cfg["model"].(map[string]any)["params"] = map[string]any{"temperature": 0.2}
+			},
+			wantErr: []string{"agent.weather", "model.params.temperature", "unsupported", "speed"},
+		},
+		{
+			name:    "http tool source",
+			mutate:  replaceToolsWithKind("weather_http", "http"),
+			wantErr: []string{"tool.weather_http", `source kind "http"`, "MCP-server wrapper"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setFullMCPEnv(t)
+			cfg := loadObject(t, "full_spec.json")
+			tt.mutate(cfg)
+
+			_, err := New().Diff(&provider.Resource{Addr: "agent.weather", Config: cfg}, nil)
+			if err == nil {
+				t.Fatal("Diff against an absent remote succeeded, want validation error")
+			}
+			for _, text := range tt.wantErr {
+				if !strings.Contains(err.Error(), text) {
+					t.Errorf("error %q does not contain %q", err, text)
+				}
+			}
+		})
+	}
+}
+
+func TestDiffCreatePathReturnsTheAttributesCreateWillSet(t *testing.T) {
+	diffs, err := New().Diff(fullResource(t), nil)
+	if err != nil {
+		t.Fatalf("Diff against an absent remote: %v", err)
+	}
+
+	paths := map[string]bool{}
+	for _, d := range diffs {
+		if d.Old != nil {
+			t.Errorf("%s: Old = %v, want nil — nothing exists remotely yet", d.Path, d.Old)
+		}
+		if d.New == nil {
+			t.Errorf("%s: unset attribute reported as an addition", d.Path)
+		}
+		paths[d.Path] = true
+	}
+	for _, want := range []string{"name", "model", "system", "description", "tools", "mcp_servers"} {
+		if !paths[want] {
+			t.Errorf("create diffs do not set %s: %+v", want, diffs)
+		}
+	}
+	// The ownership marker is stamped by Create, not user configuration.
+	if paths["metadata."+managedMarkerKey] {
+		t.Errorf("create diffs expose the %s marker: %+v", managedMarkerKey, diffs)
+	}
+}
+
 func TestDiffRequiresMCPServerURLAtPlanTime(t *testing.T) {
 	t.Setenv("KASTOR_MCP_GITHUB_URL", "")
 	_, err := New().Diff(

--- a/internal/provider/memory/memory.go
+++ b/internal/provider/memory/memory.go
@@ -84,17 +84,28 @@ func (p *Provider) Delete(_ context.Context, id string) error {
 
 // Diff implements provider.Provider via DiffObjects: the stored objects are
 // exactly the neutral configs that created them, so the generic structural
-// comparison is this platform's authoritative diff.
+// comparison is this platform's authoritative diff. Nothing in a spec is
+// unmappable onto a map in process memory, so the create path (nil remote)
+// never rejects a config here.
 func (p *Provider) Diff(desired *provider.Resource, remote provider.Object) ([]provider.AttrDiff, error) {
+	if desired == nil {
+		return nil, fmt.Errorf("memory: desired resource is nil")
+	}
 	return DiffObjects(desired.Config, remote), nil
 }
 
 // DiffObjects structurally compares two JSON value trees: maps diff by
 // sorted key union, same-length arrays element-wise, anything else as a
 // leaf. Old is the remote value, New the desired one. Output order is
-// deterministic (sorted key order). Exported so providertest's fake diffs
-// with the same algorithm and the two can never disagree.
+// deterministic (sorted key order). A nil remote means the object does not
+// exist yet and reads as an empty object, so every desired attribute comes
+// back as an addition rather than the whole tree as one leaf. Exported so
+// providertest's fake diffs with the same algorithm and the two can never
+// disagree.
 func DiffObjects(desired, remote provider.Object) []provider.AttrDiff {
+	if remote == nil {
+		remote = provider.Object{}
+	}
 	var diffs []provider.AttrDiff
 	diffValue("", desired, remote, &diffs)
 	return diffs

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -30,7 +30,7 @@ type Change struct {
 	Action Action     `json:"action"`
 	ID     string     `json:"id,omitempty"`     // remote id; empty for creates
 	Reason string     `json:"reason,omitempty"` // why this action was chosen
-	Diffs  []AttrDiff `json:"diffs,omitempty"`  // desired vs. remote (updates)
+	Diffs  []AttrDiff `json:"diffs,omitempty"`  // attributes the change sets: desired vs. remote (updates), desired vs. nothing (creates)
 	Drift  []AttrDiff `json:"drift,omitempty"`  // last-applied vs. remote (informational)
 }
 
@@ -97,6 +97,11 @@ type Job struct {
 // is gone → create (with a drift warning); otherwise the provider's Diff
 // against the desired config decides update vs. noop, and its Diff against
 // the last-applied config detects drift (remote changed outside kastor).
+//
+// Creates are not taken on trust: the provider's Diff is called against an
+// absent (nil) remote, so a spec the target cannot express — an unsupported
+// tool source kind, a foreign model provider — fails here instead of
+// half-way through apply.
 func BuildPlan(ctx context.Context, p Provider, job *Job) (*Plan, error) {
 	plan := &Plan{Target: job.Target.Name}
 	resources := stateResources(job)
@@ -115,7 +120,11 @@ func BuildPlan(ctx context.Context, p Provider, job *Job) (*Plan, error) {
 
 		st, tracked := resources[addr]
 		if !tracked {
-			plan.Changes = append(plan.Changes, Change{Addr: addr, Action: ActionCreate, Reason: "not in state"})
+			change, err := planCreate(p, job, desired, "not in state")
+			if err != nil {
+				return nil, err
+			}
+			plan.Changes = append(plan.Changes, change)
 			continue
 		}
 
@@ -124,11 +133,11 @@ func BuildPlan(ctx context.Context, p Provider, job *Job) (*Plan, error) {
 			return nil, fmt.Errorf("%s: reading remote object %s: %w", addr, st.ID, err)
 		}
 		if !found {
-			plan.Changes = append(plan.Changes, Change{
-				Addr:   addr,
-				Action: ActionCreate,
-				Reason: fmt.Sprintf("remote object %s missing", st.ID),
-			})
+			change, err := planCreate(p, job, desired, fmt.Sprintf("remote object %s missing", st.ID))
+			if err != nil {
+				return nil, err
+			}
+			plan.Changes = append(plan.Changes, change)
 			plan.Diagnostics = append(plan.Diagnostics, Diagnostic{
 				Severity: SeverityWarning,
 				Addr:     addr,
@@ -226,6 +235,20 @@ func desiredResource(job *Job, addr string) (*Resource, error) {
 		return nil, err
 	}
 	return &Resource{Addr: addr, Config: cfg}, nil
+}
+
+// planCreate builds the create change for a resource with no remote object,
+// asking the provider to render the desired config against an absent remote
+// first (Provider.Diff's create-path contract). A provider that cannot map
+// the spec onto its platform reports it here, which is the whole point: plan
+// must not green-light a module that apply would reject. On success the
+// returned diffs are the attributes the create will set.
+func planCreate(p Provider, job *Job, desired *Resource, reason string) (Change, error) {
+	diffs, err := p.Diff(desired, nil)
+	if err != nil {
+		return Change{}, fmt.Errorf("%s: cannot be created on target.%s: %w", desired.Addr, job.Target.Name, err)
+	}
+	return Change{Addr: desired.Addr, Action: ActionCreate, Reason: reason, Diffs: diffs}, nil
 }
 
 // removedFromSpec plans deletes for resources tracked in state whose block

--- a/internal/provider/plan_test.go
+++ b/internal/provider/plan_test.go
@@ -107,8 +107,72 @@ func TestBuildPlanFreshModuleCreatesInTopoOrder(t *testing.T) {
 	if len(plan.Diagnostics) != 0 {
 		t.Errorf("unexpected diagnostics: %+v", plan.Diagnostics)
 	}
-	if len(fake.Calls) != 0 {
-		t.Errorf("plan against empty state made provider calls: %v", fake.Calls)
+
+	// Every create is validated through the provider, and the diffs it
+	// returns are the attributes the create will set.
+	wantCalls := []string{"diff agent.geocoder", "diff agent.forecast", "diff agent.weather"}
+	if diff := cmp.Diff(wantCalls, fake.Calls); diff != "" {
+		t.Errorf("provider calls (-want +got):\n%s", diff)
+	}
+	for _, c := range plan.Changes {
+		if len(c.Diffs) == 0 {
+			t.Errorf("%s: create carries no attribute diffs", c.Addr)
+		}
+		for _, d := range c.Diffs {
+			if d.Old != nil {
+				t.Errorf("%s: create diff %s has Old = %v, want nil", c.Addr, d.Path, d.Old)
+			}
+		}
+	}
+}
+
+// TestBuildPlanCreateRejectedByProviderFails is the KAS-55 regression: a
+// module the target cannot express must fail at plan, not at apply.
+func TestBuildPlanCreateRejectedByProviderFails(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*provider.Job, *providertest.Fake)
+	}{
+		{
+			name:  "absent from state",
+			setup: func(*provider.Job, *providertest.Fake) {},
+		},
+		{
+			name: "tracked but remote object is gone",
+			setup: func(job *provider.Job, fake *providertest.Fake) {
+				ids := seedAll(t, job, fake)
+				delete(fake.Objects, ids["agent.forecast"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := newJob(t)
+			fake := providertest.New()
+			tt.setup(job, fake)
+			unmappable := errors.New(`tool.rest: source kind "http" cannot be mapped to this platform`)
+			fake.FailOn = map[string]error{"diff agent.forecast": unmappable}
+
+			_, err := provider.BuildPlan(context.Background(), fake, job)
+			if err == nil {
+				t.Fatal("BuildPlan succeeded, want error")
+			}
+			if !errors.Is(err, unmappable) {
+				t.Errorf("error %v does not wrap the provider error", err)
+			}
+			for _, want := range []string{"agent.forecast", "target.fake"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q missing %q", err, want)
+				}
+			}
+			// No mutating call may precede the failure.
+			for _, call := range fake.Calls {
+				if !strings.HasPrefix(call, "read ") && !strings.HasPrefix(call, "diff ") {
+					t.Errorf("plan issued mutating call %q", call)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,6 +48,13 @@ type AttrDiff struct {
 //     means "in sync". The engine calls it with the spec's desired config
 //     (update-or-noop decision) and with the last-applied config from state
 //     (drift detection).
+//   - Diff must accept a nil remote, which means the object does not exist
+//     on the platform. It must then validate the desired config exactly as
+//     it would against an existing object — returning an error is how a
+//     provider rejects a spec it cannot map onto its platform — and on
+//     success return one AttrDiff per attribute a Create would set (Old nil).
+//     The engine calls Diff this way for every resource it plans to create,
+//     so a module that cannot apply fails at plan rather than at apply.
 //   - Diff must be pure and deterministic; Read must not mutate anything.
 //     kastor plan issues only Read and Diff calls.
 type Provider interface {

--- a/mintlify/AGENTS.md
+++ b/mintlify/AGENTS.md
@@ -26,7 +26,7 @@
 
 ## Content boundaries
 
-- Claude Managed Agents (`target "claude_agents"`) ships: `plan`, `apply`, and `destroy` all work against it. Document its real constraints rather than softening them — unsupported tool kinds and model params are errors, `destroy` archives irreversibly, and those errors surface at apply, not at `kastor validate`. `target "memory"` is still the credential-free demo platform. Never present OpenAI Assistants or Bedrock Agents Classic as targets — both are sunset.
+- Claude Managed Agents (`target "claude_agents"`) ships: `plan`, `apply`, and `destroy` all work against it. Document its real constraints rather than softening them — unsupported tool kinds and model params are errors, `destroy` archives irreversibly, and those errors surface at `plan` (the provider is asked to render every planned create), not at `kastor validate`, which stays provider-agnostic. `target "memory"` is still the credential-free demo platform. Never present OpenAI Assistants or Bedrock Agents Classic as targets — both are sunset.
 - Do not claim package-manager installation exists unless verified.
 - Do not document `adl.hcl` as implemented unless the parser supports it.
 - Do not document `kastor compile`; use `kastor build`.

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -229,7 +229,7 @@ export KASTOR_MCP_SEARCH_SERVER_URL="https://mcp.tavily.com/mcp/?tavilyApiKey=tv
 
 `ANTHROPIC_API_KEY` is the default credential. The `auth` block above only names it explicitly; you can point `api_key_env` at any other variable, or omit `auth` entirely.
 
-MCP endpoints are deployment configuration, never spec — the `mcp://` URI pins server and tool identity only. For each server a URI names, kastor reads `KASTOR_MCP_<SERVER>_URL`: the server name uppercased, with every character outside `A-Z0-9` replaced by `_`. So `mcp://search-server/tavily_search` needs `KASTOR_MCP_SEARCH_SERVER_URL`. A missing one fails the apply and names the variable it wanted.
+MCP endpoints are deployment configuration, never spec — the `mcp://` URI pins server and tool identity only. For each server a URI names, kastor reads `KASTOR_MCP_<SERVER>_URL`: the server name uppercased, with every character outside `A-Z0-9` replaced by `_`. So `mcp://search-server/tavily_search` needs `KASTOR_MCP_SEARCH_SERVER_URL`. A missing one fails the plan and names the variable it wanted.
 
 ### Plan and apply
 

--- a/mintlify/reference/cli.mdx
+++ b/mintlify/reference/cli.mdx
@@ -246,9 +246,9 @@ Implemented providers:
 | `claude_agents` | Implemented. Claude Managed Agents, the hosted provider. See [platform providers](#platform-providers). |
 | `memory` | Implemented. Ephemeral in-memory provider for local demos and tests. |
 
-<Warning>
-  A clean plan is not a validity check. For a resource kastor has not created yet there is no remote object to read and nothing calls the provider, so provider-level errors — an unsupported tool kind, an unsupported model param — do not appear until `kastor apply`.
-</Warning>
+<Note>
+  Planned creates are validated, not assumed. Even with no remote object to compare against, kastor asks the provider to render the agent for the target, so provider-level errors — an unsupported tool kind, an unsupported model param — fail the plan naming the resource, rather than surfacing half-way through an apply.
+</Note>
 
 ## `kastor apply`
 
@@ -321,7 +321,7 @@ The Managed Agents resource is narrower than the Kastor agent block, and fields 
 | `input` / `output` blocks | Not sent. Managed Agents has no IO-contract field. The blocks stay valid spec and still drive references and validation, but they are not part of the remote object and never appear in a diff. |
 
 <Warning>
-  Every row above is enforced by the provider, not by `kastor validate` — which is target-agnostic and knows nothing about any provider. For a resource already in state the check runs during `plan`; for one kastor has not created yet, nothing calls the provider until `apply`.
+  Every row above is enforced by the provider, not by `kastor validate` — which is target-agnostic and knows nothing about any provider. The check runs during `plan`, for resources already in state and for ones kastor has not created yet alike, and reads `agent.x: cannot be created on target.claude_agents: …`.
 </Warning>
 
 Failures are classified: authentication (`401`/`403`, naming the env var to check), not-found, out-of-band update conflict (`409`, telling you to re-run `kastor plan`), and transient (`429`/`5xx`), which is retried to a total of three attempts, honoring `Retry-After`. Apply stops at the first failure with everything applied up to that point already saved in state, so a re-run plans exactly the remainder.

--- a/mintlify/roadmap.mdx
+++ b/mintlify/roadmap.mdx
@@ -38,7 +38,7 @@ Kastor is early. The useful distinction is what works today, what belongs in v0,
 
 ## Known gaps
 
-- Provider constraints are not checked by `kastor validate`. It is target-agnostic, so a module that no platform provider can accept still validates. On `claude_agents`, an unsupported tool kind or model param surfaces at `apply` — or at `plan` only once the resource exists in state. See [platform providers](/reference/cli#platform-providers).
+- Provider constraints are not checked by `kastor validate`. It is target-agnostic, so a module that no platform provider can accept still validates; on `claude_agents`, an unsupported tool kind or model param is caught one step later, at `plan`. See [platform providers](/reference/cli#platform-providers).
 - The weather example runs on codegen and the `memory` platform, not on `claude_agents`: its model uses `provider = "openai"`, which the hosted provider rejects.
 - An agent's `input` and `output` blocks have no counterpart in the Claude Managed Agents resource, so they are not reconciled to that target.
 


### PR DESCRIPTION
## The bug

`BuildPlan` never called the provider for a resource absent from state (`plan.go:117-120`, and the same shape on the remote-missing path). A module whose spec cannot map onto the target planned clean and exited 0, then failed part-way through apply:

```console
$ kastor plan
  + agent.probe (not in state)

Plan for target.claude_agents: 1 to create, 0 to update, 0 to delete, 0 unchanged.

$ kastor apply
kastor: agent.probe: create failed (0 of 1 changes applied, state saved): tool.read: source kind "http" cannot be mapped to Claude Managed Agents; …
```

## The fix

Both create paths now call the provider's `Diff` against an absent (nil) remote and propagate any error as a plan error naming the resource and the target:

```console
$ kastor validate
Success! Module is valid: 1 agent, 1 tool, 1 prompt, 1 model, 1 target.

$ kastor plan
kastor: agent.probe: cannot be created on target.claude_agents: tool.read: source kind "http" cannot be mapped to Claude Managed Agents; custom tools are client-executed and kastor is not a runtime; use an MCP-server wrapper with source kind "mcp"
$ echo $?
1
```

No interface change. The contract comment (and SPEC.md §6) now states explicitly what `Diff` must do when the remote object does not exist: validate the desired config exactly as it would against an existing object — an error is how a provider rejects a spec it cannot map — and otherwise return one attribute diff per attribute a `Create` would set.

Both shipped providers needed a nil-remote path:

- **claude** — skips the API-echo normalization and the managed-marker assertion (nothing to assert before `Create` stamps it) while still normalizing the spec in full, which is what does the rejecting. Its comparator also stopped treating an absent key with a null desired value as an addition, so unset optional fields don't read as attributes a create will set.
- **memory** — reads a nil remote as the empty object, so a create diffs per attribute rather than as one whole-tree leaf. Nothing in a spec is unmappable onto a map in process memory, so it never rejects.

This also moves the missing-`KASTOR_MCP_<SERVER>_URL` error from apply to plan, which is the same class of problem.

## Plan output

Unchanged. The returned diffs populate `Change.Diffs` (already JSON-tagged for the future `--json` rendering, and now covered by tests), but the text renderer still prints a create as one line. Rendering the attributes under creates the way updates render works and is three lines of code, but `renderValue` truncates at 60 chars and a create's values are whole subtrees, so it comes out as a wall of truncated JSON plus noise lines like `skills: []` — and it would rewrite the plan-output snippet in every doc page. That is a plan-output redesign, so it is left out. Happy to do it as a follow-up if you want it.

<details>
<summary>What it would look like today</summary>

```console
  + agent.weather (not in state)
      description: "Answers weather questions for a location and date"
      inputs: [{"description":"The location to get the weather for","name…
      instructions: "You are a weather assistant. The user is asking about {{lo…
      model: {"id":"gpt-4o-mini","params":{"max_tokens":4096,"temperatur…
      outputs: [{"name":"weather","type":"string"}]
      tools: [{"description":"Search the web","name":"web_search","param…
```
</details>

## Tests

- `cmd/kastor` — new `testdata/claude_plan` fixture: an http tool source, a non-anthropic model provider, and an unsupported model param each fail `kastor plan` with exit 1 and write no state file, and each still passes `kastor validate` first. Plus the happy path: a valid module still plans as a create.
- `internal/provider/claude` — `Diff` against a nil remote surfaces the same three mapping errors, and on a valid spec returns the create's attributes with `Old` nil and no `kastor_managed` marker.
- `internal/provider` — a provider that rejects a create fails the plan on both create paths (absent from state, remote object gone), with no mutating call before the failure; the fresh-module plan asserts the diff calls and the attributes each create carries.

## Docs

The "clean plan is not a validity check" caveat becomes "caught at plan" in README.md, `mintlify/reference/cli.mdx`, `mintlify/roadmap.mdx`, and `mintlify/AGENTS.md`, plus the two "fails the apply" claims about `KASTOR_MCP_<SERVER>_URL`. The note that `kastor validate` is itself provider-agnostic is kept everywhere it appeared — that is still true. CHANGELOG.md has the entry under `[Unreleased]` / `Fixed`.

## Verification

`go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` all clean. `kastor validate` + `kastor plan` run against all three examples and against the new fixture; `kastor apply` and the ephemeral-platform replan on `examples/weather` produce the documented output.