### PR TITLE
fix: grant declared tools on the Claude platform (KAS-57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Kastor is pre-1.0: the v0 language semantics may still change until the
-v0 exit criteria ([KAS-36](https://linear.app/getkastor/issue/KAS-36)) are met.
+v0 exit criteria KAS-36 are met.
 
 ## [Unreleased]
+
+### Fixed
+
+- `claude_agents`: agents applied to the Claude Managed Agents platform came up
+  with every MCP tool denied, so `apply` reported success, `plan` reported no
+  drift, and the deployed agent could not call a tool it declared (KAS-57)
+
+  The provider created the agent without stating a per-tool permission, and the
+  platform's own default for an unset permission is the restrictive one.
+  Declaring a tool in the spec is now the grant: `create` sets
+  `permission_policy` to `always_allow` on every tool in the agent closure, the
+  permission is part of the compared object — so a tool flipped to deny in the
+  Console is reported as drift — and `apply` reconciles it back to the spec.
+  Making the policy configurable in the spec is a later design pass
+  KAS-62; until then every
+  declared tool is allowed.
+
+  The first plan after upgrading an agent applied by an earlier version reports
+  the remote denial as drift and proposes the converging update.
 
 ### Added
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,11 +68,18 @@ Nothing below is automated. Work through it before you tag.
 export KASTOR_ACCEPTANCE=1
 export ANTHROPIC_API_KEY=...
 export KASTOR_MCP_KASTOR_ACCEPTANCE_URL=...   # must expose an "echo" tool
+export KASTOR_MCP_ACCEPTANCE_TOOL=...         # optional: name the tool it does expose
 go test ./cmd/kastor -run TestClaudeManagedAgentsAcceptance -v -count=1
 ```
 
-The test skips unless all three variables are set, so a normal `go test ./...`
-never runs it.
+The test skips unless the first three variables are set, so a normal
+`go test ./...` never runs it.
+
+`KASTOR_MCP_ACCEPTANCE_TOOL` exists because the live session step has to call a
+tool that actually exists: the acceptance module declares `echo`, and a server
+that serves something else needs its own tool named here (`tavily_search`, for
+instance). Only the name matters — a tool block's params are not sent to
+Managed Agents, because the MCP server owns the schema.
 
 **Why this is manual and not in CI:**
 
@@ -84,6 +91,15 @@ never runs it.
 - **Plan output includes the MCP server URL**, which is deployment
   configuration and frequently carries a key in its query string. A CI log is
   public; that URL must not land in one.
+
+The run also **starts one live session** against the created agent (KAS-57): it
+provisions a cloud environment, asks the agent to call its MCP `echo` tool, and
+asserts the platform evaluated that call as `allow`. This costs one short model
+turn and is the only check that the tool permission kastor writes actually
+reaches the deployed agent — a permission that is stored but ignored looks
+identical to every CRUD assertion. The session and environment are deleted
+afterwards; unlike the agent, both are reversible. The test logs the session's
+Console trace URL, which is worth opening if the turn fails.
 
 **Each run permanently archives an agent.** The test creates a real agent and
 destroys it, and `destroy` on this target means *archive*, which is

--- a/cmd/kastor/claude_acceptance_test.go
+++ b/cmd/kastor/claude_acceptance_test.go
@@ -45,6 +45,7 @@ func TestClaudeManagedAgentsAcceptance(t *testing.T) {
 	t.Cleanup(func() { providerFactories[claudeAcceptanceTarget] = realFactory })
 
 	dir := copyModule(t, "testdata/claude_acceptance")
+	retargetAcceptanceMCPTool(t, dir)
 	destroyed := false
 	t.Cleanup(func() {
 		if destroyed {
@@ -78,6 +79,14 @@ func TestClaudeManagedAgentsAcceptance(t *testing.T) {
 		t.Fatalf("construct real Claude provider: %v", err)
 	}
 	assertAcceptanceMetadata(t, realProvider, resource.ID, marker)
+
+	// 1b. Create states the tool permission (KAS-57): every tool in the agent
+	// closure is granted on the remote object, without a console edit.
+	assertAcceptanceToolGrants(t, realProvider, resource.ID, acceptanceAllowPolicy)
+
+	// 1c. The grant is only worth anything if the agent can use it, so run one
+	// live turn and watch the platform evaluate the MCP call.
+	assertMCPToolIsCallable(t, resource.ID)
 
 	// 2. A plan immediately after creation is clean.
 	out = runAcceptanceCLI(t, "plan", dir)
@@ -128,6 +137,30 @@ func TestClaudeManagedAgentsAcceptance(t *testing.T) {
 		"Warning: "+claudeAcceptanceAddr+": remote object changed outside kastor",
 		"changed attributes: description",
 		"Plan for target.claude_agents: 0 to create, 1 to update, 0 to delete, 0 unchanged.",
+	)
+
+	// 5b. KAS-57's negative case: a tool whose grant is taken away outside
+	// kastor is drift, and apply reconciles the attribute back to the spec.
+	gated := gateAcceptanceToolOutOfBand(t, realProvider, resource.ID)
+	assertAcceptanceToolPolicy(t, realProvider, resource.ID, gated, acceptanceGatedPolicy)
+
+	out = runAcceptanceCLI(t, "plan", dir)
+	assertOutputContains(t, out,
+		"~ "+claudeAcceptanceAddr,
+		"Warning: "+claudeAcceptanceAddr+": remote object changed outside kastor",
+		// tools is a replace-whole array, so the diff names the changed
+		// toolset rather than the leaf attribute inside it.
+		"tools[",
+	)
+
+	out = runAcceptanceCLI(t, "apply", dir)
+	assertOutputContains(t, out,
+		"Applied target.claude_agents: 0 created, 1 updated, 0 deleted.",
+	)
+	assertAcceptanceToolGrants(t, realProvider, resource.ID, acceptanceAllowPolicy)
+	out = runAcceptanceCLI(t, "plan", dir)
+	assertOutputContains(t, out,
+		"No changes for target.claude_agents: remote matches the spec (1 resource).",
 	)
 
 	// 6. Destroy archives the live agent through KAS-22's existing CLI path.

--- a/cmd/kastor/claude_permission_acceptance_test.go
+++ b/cmd/kastor/claude_permission_acceptance_test.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+
+	"github.com/weirdGuy/kastor/internal/provider"
+)
+
+// KAS-57 acceptance helpers. Declaring a tool in the spec is the grant, so the
+// checks here are about what the deployed agent may do, not only about what
+// kastor sent: a create that records the right attribute but leaves the agent
+// unable to call its tools is the exact failure this ticket closes.
+const (
+	acceptanceAllowPolicy = "always_allow"
+	// acceptanceGatedPolicy is the out-of-band change the drift test makes.
+	// It is not "always_deny": managed-agents-2026-04-01 rejects that value
+	// (400, `"always_deny" is not a valid value`), so always_ask is the only
+	// policy the API accepts that is not the grant. Do not "fix" this to deny.
+	acceptanceGatedPolicy = "always_ask"
+	// acceptanceMCPToolEnv overrides the MCP tool the acceptance module
+	// declares, for servers that expose something other than "echo".
+	acceptanceMCPToolEnv     = "KASTOR_MCP_ACCEPTANCE_TOOL"
+	acceptanceDefaultMCPTool = "echo"
+	// acceptanceSessionTimeout bounds the live tool-call turn. The session is a
+	// container start plus one model turn, so this is generous on purpose.
+	acceptanceSessionTimeout = 5 * time.Minute
+)
+
+// acceptanceMCPTool is the tool name the acceptance agent declares on its MCP
+// server. Only the name reaches Managed Agents — the tool block's params are
+// not sent, because the server owns the schema — so pointing the module at
+// whatever tool the configured server actually exposes is enough to exercise
+// the permission end to end.
+func acceptanceMCPTool() string {
+	if name := strings.TrimSpace(os.Getenv(acceptanceMCPToolEnv)); name != "" {
+		return name
+	}
+	return acceptanceDefaultMCPTool
+}
+
+// retargetAcceptanceMCPTool rewrites the copied module's MCP URI so the agent
+// declares a tool the configured server serves. A tool the server does not
+// expose is never offered to the model, and a turn that never calls the tool
+// cannot demonstrate anything about its permission.
+func retargetAcceptanceMCPTool(t *testing.T, dir string) {
+	t.Helper()
+	name := acceptanceMCPTool()
+	if name == acceptanceDefaultMCPTool {
+		return
+	}
+	path := filepath.Join(dir, "acceptance.tool")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read acceptance tool: %v", err)
+	}
+	const old = "mcp://kastor-acceptance/" + acceptanceDefaultMCPTool
+	if !strings.Contains(string(data), old) {
+		t.Fatalf("acceptance tool does not declare %s", old)
+	}
+	updated := strings.Replace(string(data), old, "mcp://kastor-acceptance/"+name, 1)
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		t.Fatalf("retarget acceptance tool: %v", err)
+	}
+	t.Logf("acceptance MCP tool retargeted to %q via %s", name, acceptanceMCPToolEnv)
+}
+
+// assertAcceptanceToolGrants reads the live agent and checks that every tool
+// in the closure carries the grant. Reading the remote (rather than the
+// request kastor built) is the point: it proves the platform stored the
+// permission instead of applying its own restrictive default.
+func assertAcceptanceToolGrants(t *testing.T, p provider.Provider, id, want string) {
+	t.Helper()
+	remote, found, err := p.Read(context.Background(), id)
+	if err != nil {
+		t.Fatalf("read Claude agent %s: %v", id, err)
+	}
+	if !found {
+		t.Fatalf("Claude agent %s was not found", id)
+	}
+
+	tools, ok := remote["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		t.Fatalf("remote agent declares no tools: %#v", remote["tools"])
+	}
+	seen := 0
+	for i, rawToolset := range tools {
+		toolset := rawToolset.(map[string]any)
+		configs, ok := toolset["configs"].([]any)
+		if !ok {
+			t.Fatalf("remote tools[%d].configs = %#v, want an array", i, toolset["configs"])
+		}
+		for j, rawConfig := range configs {
+			config := rawConfig.(map[string]any)
+			seen++
+			policy, ok := config["permission_policy"].(map[string]any)
+			if !ok {
+				t.Errorf("remote tools[%d].configs[%d] (%v) has no permission_policy: %#v",
+					i, j, config["name"], config)
+				continue
+			}
+			if got := policy["type"]; got != want {
+				t.Errorf("remote tools[%d].configs[%d] (%v) permission_policy.type = %v, want %q",
+					i, j, config["name"], got, want)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatalf("remote agent declares toolsets but no tool configs: %#v", tools)
+	}
+	t.Logf("remote agent %s: %d declared tools carry permission_policy %q", id, seen, want)
+}
+
+// assertAcceptanceToolPolicy checks one named tool's live permission, for the
+// half-gated state the drift step creates: the tools kastor did not touch must
+// keep their grant.
+func assertAcceptanceToolPolicy(t *testing.T, p provider.Provider, id, tool, want string) {
+	t.Helper()
+	remote, found, err := p.Read(context.Background(), id)
+	if err != nil || !found {
+		t.Fatalf("read Claude agent %s: %v (found=%v)", id, err, found)
+	}
+	for _, rawToolset := range remote["tools"].([]any) {
+		for _, rawConfig := range rawToolset.(map[string]any)["configs"].([]any) {
+			config := rawConfig.(map[string]any)
+			if fmt.Sprintf("%v", config["name"]) != tool {
+				continue
+			}
+			policy, _ := config["permission_policy"].(map[string]any)
+			if policy == nil || policy["type"] != want {
+				t.Fatalf("remote tool %q permission_policy = %#v, want %q", tool, config["permission_policy"], want)
+			}
+			return
+		}
+	}
+	t.Fatalf("remote agent %s declares no tool named %q", id, tool)
+}
+
+// gateAcceptanceToolOutOfBand takes the grant away from one MCP tool the way
+// a console edit would: a full-replacement update sent outside kastor, leaving
+// state untouched. It returns the tool it gated.
+func gateAcceptanceToolOutOfBand(t *testing.T, p provider.Provider, id string) string {
+	t.Helper()
+	remote, found, err := p.Read(context.Background(), id)
+	if err != nil || !found {
+		t.Fatalf("read Claude agent %s: %v (found=%v)", id, err, found)
+	}
+
+	request := provider.Object{}
+	for key, value := range remote {
+		switch key {
+		case "id", "type", "created_at", "updated_at", "archived_at":
+			// Response envelope; not an updatable field.
+		default:
+			request[key] = value
+		}
+	}
+
+	gated := ""
+	for _, rawToolset := range request["tools"].([]any) {
+		toolset := rawToolset.(map[string]any)
+		if toolset["type"] != "mcp_toolset" {
+			continue
+		}
+		for _, rawConfig := range toolset["configs"].([]any) {
+			config := rawConfig.(map[string]any)
+			config["permission_policy"] = map[string]any{"type": acceptanceGatedPolicy}
+			gated = fmt.Sprintf("%v", config["name"])
+			break
+		}
+		break
+	}
+	if gated == "" {
+		t.Fatal("acceptance agent declares no MCP tool to gate")
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("encode out-of-band update: %v", err)
+	}
+	var params anthropic.BetaAgentUpdateParams
+	param.SetJSON(body, &params)
+	client := acceptanceClient(t)
+	if _, err := client.Beta.Agents.Update(context.Background(), id, params); err != nil {
+		t.Fatalf("gate %q out of band: %v", gated, err)
+	}
+	t.Logf("out-of-band edit: MCP tool %q set to %s on %s", gated, acceptanceGatedPolicy, id)
+	return gated
+}
+
+// assertMCPToolIsCallable runs the deployed agent for one turn and checks that
+// its MCP tool actually executes. This is the acceptance criterion no CRUD
+// assertion can stand in for: with the permission unset the platform evaluates
+// the call as a denial, the plan is still clean, and the agent is useless.
+func assertMCPToolIsCallable(t *testing.T, agentID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), acceptanceSessionTimeout)
+	defer cancel()
+	client := acceptanceClient(t)
+
+	stamp := time.Now().UTC().Format("20060102T150405")
+	environment, err := client.Beta.Environments.New(ctx, anthropic.BetaEnvironmentNewParams{
+		Name: "kastor-kas-57-" + stamp,
+		Config: anthropic.BetaEnvironmentNewParamsConfigUnion{
+			OfCloud: &anthropic.BetaCloudConfigParams{
+				Networking: anthropic.BetaCloudConfigParamsNetworkingUnion{
+					OfUnrestricted: &anthropic.BetaUnrestrictedNetworkParam{},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create acceptance environment: %v", err)
+	}
+
+	session, err := client.Beta.Sessions.New(ctx, anthropic.BetaSessionNewParams{
+		Agent:         anthropic.BetaSessionNewParamsAgentUnion{OfString: anthropic.String(agentID)},
+		EnvironmentID: environment.ID,
+		Title:         anthropic.String("KAS-57 tool permission acceptance " + stamp),
+	})
+	if err != nil {
+		t.Fatalf("create acceptance session: %v", err)
+	}
+	t.Logf("session trace: https://platform.claude.com/workspaces/default/sessions/%s", session.ID)
+
+	// Sessions and environments are reversible, unlike the agent archive the
+	// lifecycle test accepts, so this run leaves nothing behind.
+	t.Cleanup(func() {
+		cleanup, cancelCleanup := context.WithTimeout(context.Background(), time.Minute)
+		defer cancelCleanup()
+		if _, err := client.Beta.Sessions.Delete(cleanup, session.ID, anthropic.BetaSessionDeleteParams{}); err != nil {
+			t.Errorf("delete acceptance session %s: %v", session.ID, err)
+			return
+		}
+		if _, err := client.Beta.Environments.Delete(cleanup, environment.ID, anthropic.BetaEnvironmentDeleteParams{}); err != nil {
+			t.Errorf("delete acceptance environment %s: %v", environment.ID, err)
+		}
+	})
+
+	// Stream first: the stream only carries events emitted after it opens.
+	stream := client.Beta.Sessions.Events.StreamEvents(ctx, session.ID, anthropic.BetaSessionEventStreamParams{})
+	defer stream.Close()
+
+	tool := acceptanceMCPTool()
+	prompt := fmt.Sprintf(
+		"Call your %q MCP tool exactly once, with any reasonable input for it "+
+			"(use \"kastor-kas-57\" wherever a free-text value is needed). "+
+			"Then reply with what it returned. Do not ask for confirmation.", tool)
+	if _, err := client.Beta.Sessions.Events.Send(ctx, session.ID, anthropic.BetaSessionEventSendParams{
+		Events: []anthropic.BetaManagedAgentsEventParamsUnion{{
+			OfUserMessage: &anthropic.BetaManagedAgentsUserMessageEventParams{
+				Type: anthropic.BetaManagedAgentsUserMessageEventParamsTypeUserMessage,
+				Content: []anthropic.BetaManagedAgentsUserMessageEventParamsContentUnion{{
+					OfText: &anthropic.BetaManagedAgentsTextBlockParam{
+						Type: anthropic.BetaManagedAgentsTextBlockTypeText,
+						Text: prompt,
+					},
+				}},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("send acceptance user message: %v", err)
+	}
+
+	var (
+		permission string
+		called     bool
+		toolErr    bool
+		blocked    bool
+		reply      string
+	)
+	for stream.Next() {
+		switch event := stream.Current().AsAny().(type) {
+		case anthropic.BetaManagedAgentsAgentMCPToolUseEvent:
+			called = true
+			permission = string(event.EvaluatedPermission)
+			t.Logf("agent.mcp_tool_use %s/%s evaluated_permission=%q", event.MCPServerName, event.Name, permission)
+		case anthropic.BetaManagedAgentsAgentMessageEvent:
+			for _, block := range event.Content {
+				reply += block.Text
+			}
+		case anthropic.BetaManagedAgentsAgentMCPToolResultEvent:
+			toolErr = event.IsError
+		case anthropic.BetaManagedAgentsSessionErrorEvent:
+			t.Errorf("session error: %s", event.Error.Message)
+		case anthropic.BetaManagedAgentsSessionStatusIdleEvent:
+			// requires_action means the platform is waiting on a confirmation
+			// or a tool result — for an MCP tool that is the ask/deny gate this
+			// ticket exists to remove, so it ends the turn as a failure rather
+			// than something to answer.
+			if event.StopReason.Type == "requires_action" {
+				blocked = true
+			}
+			goto done
+		case anthropic.BetaManagedAgentsSessionStatusTerminatedEvent:
+			goto done
+		}
+	}
+done:
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream acceptance session events: %v", err)
+	}
+
+	switch {
+	case !called:
+		// Most often the configured server does not serve a tool by this name,
+		// so the platform never offers it to the model — a setup problem, not
+		// a permission one. The agent's own reply usually says which.
+		t.Errorf("agent never invoked MCP tool %q, so the turn cannot demonstrate the grant.\n"+
+			"Check that the server behind %s serves that tool, or name the one it does serve in %s.\n"+
+			"agent reply: %s", tool, claudeAcceptanceMCPEnv, acceptanceMCPToolEnv, reply)
+	case permission != "allow":
+		t.Errorf("MCP tool evaluated_permission = %q, want \"allow\" — the deployed agent cannot call a tool it declares", permission)
+	case blocked:
+		t.Errorf("session went idle awaiting action after the MCP tool call; the tool is gated, not granted")
+	case toolErr:
+		// Not a permission failure: the tool ran and the server answered with
+		// an error. Report it so a broken acceptance MCP server is not read as
+		// a kastor regression.
+		t.Errorf("MCP tool returned is_error; check the server behind %s", claudeAcceptanceMCPEnv)
+	default:
+		t.Logf("MCP tool executed with evaluated_permission=allow and no console edit")
+	}
+}
+
+func acceptanceClient(t *testing.T) anthropic.Client {
+	t.Helper()
+	return anthropic.NewClient(option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")))
+}

--- a/internal/provider/claude/claude_test.go
+++ b/internal/provider/claude/claude_test.go
@@ -83,8 +83,9 @@ func TestCreateSendsNormalizedSDKRequest(t *testing.T) {
 			toolset := raw.(map[string]any)
 			for _, rawConfig := range toolset["configs"].([]any) {
 				config := rawConfig.(map[string]any)
-				if _, exists := config["permission_policy"]; exists {
-					t.Errorf("create request authors a per-tool permission policy: %#v", config)
+				policy, ok := config["permission_policy"].(map[string]any)
+				if !ok || policy["type"] != alwaysAllowPolicy {
+					t.Errorf("create request does not grant %v: permission_policy = %#v", config["name"], config["permission_policy"])
 				}
 			}
 			if toolset["type"] != mcpToolsetType {

--- a/internal/provider/claude/normalize.go
+++ b/internal/provider/claude/normalize.go
@@ -26,6 +26,9 @@ const (
 
 	agentToolsetType = "agent_toolset_20260401"
 	mcpToolsetType   = "mcp_toolset"
+
+	alwaysAllowPolicy = "always_allow"
+	alwaysAskPolicy   = "always_ask"
 )
 
 var managedAgentTools = map[string]bool{
@@ -129,8 +132,11 @@ func normalizeUpdateParams(desired *provider.Resource, version int64) (anthropic
 }
 
 // normalizeAPIRequest removes comparison-only defaults from the normalized
-// spec. In particular, the MCP permission default must remain omitted from
-// requests so the platform applies its approval-required default.
+// spec. The MCP toolset's default permission is the only one: it governs the
+// tools the agent does not declare, so authoring it would be Kastor asserting
+// a policy over tools it was never given. Per-tool permissions are the
+// opposite — Kastor states those explicitly on every declared tool, because
+// leaving them unset is what the platform reads as a denial (see enabledTool).
 func normalizeAPIRequest(desired *provider.Resource) (provider.Object, error) {
 	spec, _, err := normalizeDesired(desired)
 	if err != nil {
@@ -139,10 +145,6 @@ func normalizeAPIRequest(desired *provider.Resource) (provider.Object, error) {
 	request := cloneValue(spec).(provider.Object)
 	for _, value := range request["tools"].([]any) {
 		toolset := value.(map[string]any)
-		for _, rawConfig := range toolset["configs"].([]any) {
-			config := rawConfig.(map[string]any)
-			delete(config, "permission_policy")
-		}
 		if toolset["type"] == mcpToolsetType {
 			defaultConfig := toolset["default_config"].(map[string]any)
 			delete(defaultConfig, "permission_policy")
@@ -548,7 +550,7 @@ func newToolset(typ, server string) *toolsetBuilder {
 	defaultConfig := map[string]any{"enabled": false}
 	if typ == agentToolsetType {
 		defaultConfig["permission_policy"] = map[string]any{
-			"type": "always_allow",
+			"type": alwaysAllowPolicy,
 		}
 	}
 	obj := map[string]any{
@@ -562,9 +564,10 @@ func newToolset(typ, server string) *toolsetBuilder {
 }
 
 // normalizeSpecToolsetDefaults applies the API's resolved response defaults
-// to the comparison copy. The request shape produced by newToolset deliberately
-// omits the MCP permission policy so the platform keeps its safe always_ask
-// default rather than Kastor authoring an approval override.
+// to the comparison copy. Only the MCP toolset default needs this: the request
+// omits it (see normalizeAPIRequest), and the platform resolves the omission
+// to always_ask for the undeclared tools that default governs. The tools the
+// agent does declare carry their own policy and never fall through to it.
 func normalizeSpecToolsetDefaults(tools []any) []any {
 	normalized := cloneValue(tools).([]any)
 	for _, value := range normalized {
@@ -574,16 +577,27 @@ func normalizeSpecToolsetDefaults(tools []any) []any {
 		}
 		defaultConfig := toolset["default_config"].(map[string]any)
 		defaultConfig["permission_policy"] = map[string]any{
-			"type": "always_ask",
+			"type": alwaysAskPolicy,
 		}
 	}
 	return normalized
 }
 
+// enabledTool renders one declared tool. Declaring a tool in the spec is the
+// grant: an agent that lists tool.y is permitted to call it, so the permission
+// is stated on the request instead of inherited. Leaving it unset is what
+// deploys agents that cannot call any of the tools they declare — the platform
+// reads an absent permission as a denial.
+//
+// TODO(KAS-62): allow is hardcoded here. Making the permission configurable in
+// the spec is that ticket's design pass; until then every declared tool is
+// allowed, deliberately rather than by omission.
 func enabledTool(name string) map[string]any {
-	// Per-tool permission policy is deliberately absent. Kastor v0 enables the
-	// selected tool and lets it inherit the toolset's default policy.
-	return map[string]any{"name": name, "enabled": true}
+	return map[string]any{
+		"name":              name,
+		"enabled":           true,
+		"permission_policy": map[string]any{"type": alwaysAllowPolicy},
+	}
 }
 
 func unsupportedToolKind(addr, kind string) error {
@@ -658,7 +672,15 @@ func normalizeEchoTools(tools []any) ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			normalizedConfigs[j] = map[string]any{"name": name, "enabled": enabled}
+			policy, err := normalizeEchoToolPermission(config["permission_policy"], configPath+".permission_policy")
+			if err != nil {
+				return nil, err
+			}
+			normalizedConfigs[j] = map[string]any{
+				"name":              name,
+				"enabled":           enabled,
+				"permission_policy": policy,
+			}
 		}
 
 		normalized := map[string]any{
@@ -676,6 +698,27 @@ func normalizeEchoTools(tools []any) ([]any, error) {
 		out[i] = normalized
 	}
 	return out, nil
+}
+
+// normalizeEchoToolPermission projects one declared tool's permission. The
+// API always returns the attribute; the absent case is a config written to
+// state before KAS-57, when Kastor authored no permission at all. Those read
+// as the grant the spec now states, so the first plan after the upgrade
+// reports the remote denial as the drift it is, rather than blaming the
+// state file for a value it never recorded.
+func normalizeEchoToolPermission(raw any, path string) (map[string]any, error) {
+	if raw == nil {
+		return map[string]any{"type": alwaysAllowPolicy}, nil
+	}
+	policy, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an object, got %T", path, raw)
+	}
+	typ, err := requiredString(policy["type"], path+".type")
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"type": typ}, nil
 }
 
 func normalizeEchoDefaultToolConfig(raw any, path string) (map[string]any, error) {

--- a/internal/provider/claude/normalize_test.go
+++ b/internal/provider/claude/normalize_test.go
@@ -85,14 +85,22 @@ func TestNormalizeStateConfigMatchesGoldenEcho(t *testing.T) {
 	}
 }
 
-func TestGoldenEchoToolConfigsContainOnlyEnablement(t *testing.T) {
+// TestGoldenEchoToolConfigsCarryPermissions pins the response shape the rest
+// of the suite is written against: the API returns a permission on every tool
+// config, so a fixture that omits one would hide exactly the attribute KAS-57
+// is about.
+func TestGoldenEchoToolConfigsCarryPermissions(t *testing.T) {
 	echo := loadObject(t, "full_api_response.json")
 	for i, rawToolset := range echo["tools"].([]any) {
 		toolset := rawToolset.(map[string]any)
 		for j, rawConfig := range toolset["configs"].([]any) {
 			config := rawConfig.(map[string]any)
-			if len(config) != 2 || config["name"] == nil || config["enabled"] == nil {
-				t.Errorf("tools[%d].configs[%d] = %#v, want only name and enabled", i, j, config)
+			if len(config) != 3 || config["name"] == nil || config["enabled"] == nil {
+				t.Errorf("tools[%d].configs[%d] = %#v, want name, enabled and permission_policy", i, j, config)
+			}
+			policy, ok := config["permission_policy"].(map[string]any)
+			if !ok || policy["type"] == "" {
+				t.Errorf("tools[%d].configs[%d].permission_policy = %#v, want a typed policy", i, j, config["permission_policy"])
 			}
 		}
 	}
@@ -126,30 +134,141 @@ func TestNormalizedStatePreservesAppliedMCPURL(t *testing.T) {
 	}
 }
 
-func TestNormalizeRequestOmitsPerToolPermissionPolicies(t *testing.T) {
-	stateConfig, err := New().NormalizeStateConfig(fullResource(t))
-	if err != nil {
-		t.Fatalf("NormalizeStateConfig: %v", err)
-	}
-	for _, rawToolset := range stateConfig["tools"].([]any) {
-		toolset := rawToolset.(map[string]any)
-		for _, rawConfig := range toolset["configs"].([]any) {
-			rawConfig.(map[string]any)["permission_policy"] = map[string]any{"type": "always_ask"}
-		}
-	}
-
-	request, err := normalizeAPIRequest(&provider.Resource{Addr: "agent.weather", Config: stateConfig})
+// TestNormalizeRequestGrantsEveryDeclaredTool is the KAS-57 contract on the
+// write path: declaring a tool is the grant, so no tool in the agent closure
+// may leave its permission to the platform's restrictive default.
+func TestNormalizeRequestGrantsEveryDeclaredTool(t *testing.T) {
+	request, err := normalizeAPIRequest(fullResource(t))
 	if err != nil {
 		t.Fatalf("normalizeAPIRequest: %v", err)
 	}
+
+	granted := map[string]any{}
 	for i, rawToolset := range request["tools"].([]any) {
 		toolset := rawToolset.(map[string]any)
 		for j, rawConfig := range toolset["configs"].([]any) {
 			config := rawConfig.(map[string]any)
-			if _, exists := config["permission_policy"]; exists {
-				t.Errorf("request.tools[%d].configs[%d] authors permission_policy: %#v", i, j, config)
+			want := map[string]any{"type": alwaysAllowPolicy}
+			if diff := cmp.Diff(want, config["permission_policy"]); diff != "" {
+				t.Errorf("request.tools[%d].configs[%d] permission (-want +got):\n%s", i, j, diff)
+			}
+			granted[config["name"].(string)] = config["permission_policy"]
+		}
+		// The MCP toolset default governs the tools the agent does not
+		// declare, so the request must still leave it to the platform.
+		if toolset["type"] != mcpToolsetType {
+			continue
+		}
+		defaultConfig := toolset["default_config"].(map[string]any)
+		if _, exists := defaultConfig["permission_policy"]; exists {
+			t.Errorf("request.tools[%d].default_config authors permission_policy: %#v", i, defaultConfig)
+		}
+	}
+
+	for _, name := range []string{"read", "write", "get_issue"} {
+		if granted[name] == nil {
+			t.Errorf("request does not grant declared tool %q: granted = %v", name, granted)
+		}
+	}
+}
+
+// TestUpdateParamsGrantEveryDeclaredTool covers the reconcile half: an agent
+// whose tools were flipped to deny in the console must be sent back to the
+// spec's grant, not merely left alone.
+func TestUpdateParamsGrantEveryDeclaredTool(t *testing.T) {
+	params, err := normalizeUpdateParams(fullResource(t), 7)
+	if err != nil {
+		t.Fatalf("normalizeUpdateParams: %v", err)
+	}
+	body, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal update params: %v", err)
+	}
+	var request provider.Object
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode update params: %v", err)
+	}
+
+	for i, rawToolset := range request["tools"].([]any) {
+		toolset := rawToolset.(map[string]any)
+		for j, rawConfig := range toolset["configs"].([]any) {
+			config := rawConfig.(map[string]any)
+			want := map[string]any{"type": alwaysAllowPolicy}
+			if diff := cmp.Diff(want, config["permission_policy"]); diff != "" {
+				t.Errorf("update.tools[%d].configs[%d] permission (-want +got):\n%s", i, j, diff)
 			}
 		}
+	}
+}
+
+// TestDiffReportsConsoleSideToolDenialAsDrift is the KAS-57 negative test: a
+// tool flipped to deny outside kastor must show up as drift naming the
+// attribute, not as a silent no-op plan.
+func TestDiffReportsConsoleSideToolDenialAsDrift(t *testing.T) {
+	desired := fullResource(t)
+	stateConfig, err := New().NormalizeStateConfig(desired)
+	if err != nil {
+		t.Fatalf("NormalizeStateConfig: %v", err)
+	}
+
+	remote := loadObject(t, "full_api_response.json")
+	mcpToolset := remote["tools"].([]any)[1].(map[string]any)
+	denied := mcpToolset["configs"].([]any)[0].(map[string]any)
+	denied["permission_policy"] = map[string]any{"type": "always_deny"}
+
+	for _, tt := range []struct {
+		name   string
+		config provider.Object
+	}{
+		{name: "against the spec", config: desired.Config},
+		{name: "against last-applied state", config: stateConfig},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			diffs, err := New().Diff(&provider.Resource{Addr: desired.Addr, Config: tt.config}, remote)
+			if err != nil {
+				t.Fatalf("Diff: %v", err)
+			}
+			if diff := cmp.Diff([]string{"tools[1]"}, paths(diffs)); diff != "" {
+				t.Fatalf("drift paths (-want +got):\n%s", diff)
+			}
+
+			old := diffs[0].Old.(map[string]any)["configs"].([]any)[0].(map[string]any)
+			if got := old["permission_policy"]; !cmp.Equal(got, map[string]any{"type": "always_deny"}) {
+				t.Errorf("drift does not report the remote denial: %#v", got)
+			}
+			want := diffs[0].New.(map[string]any)["configs"].([]any)[0].(map[string]any)
+			if got := want["permission_policy"]; !cmp.Equal(got, map[string]any{"type": alwaysAllowPolicy}) {
+				t.Errorf("drift does not name the grant kastor will restore: %#v", got)
+			}
+		})
+	}
+}
+
+// TestDiffAcceptsPreKAS57StateConfigs keeps the upgrade path quiet: a config
+// written before kastor authored permissions must still normalize, so plan
+// reports the remote denial rather than failing to read its own state.
+func TestDiffAcceptsPreKAS57StateConfigs(t *testing.T) {
+	desired := fullResource(t)
+	legacy, err := New().NormalizeStateConfig(desired)
+	if err != nil {
+		t.Fatalf("NormalizeStateConfig: %v", err)
+	}
+	for _, rawToolset := range legacy["tools"].([]any) {
+		toolset := rawToolset.(map[string]any)
+		for _, rawConfig := range toolset["configs"].([]any) {
+			delete(rawConfig.(map[string]any), "permission_policy")
+		}
+	}
+
+	diffs, err := New().Diff(
+		&provider.Resource{Addr: desired.Addr, Config: legacy},
+		loadObject(t, "full_api_response.json"),
+	)
+	if err != nil {
+		t.Fatalf("Diff pre-KAS-57 state config: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("pre-KAS-57 state config drifts against a granted remote: %#v", diffs)
 	}
 }
 

--- a/internal/provider/claude/testdata/full_api_response.json
+++ b/internal/provider/claude/testdata/full_api_response.json
@@ -20,11 +20,17 @@
       "configs": [
         {
           "name": "read",
-          "enabled": true
+          "enabled": true,
+          "permission_policy": {
+            "type": "always_allow"
+          }
         },
         {
           "name": "write",
-          "enabled": true
+          "enabled": true,
+          "permission_policy": {
+            "type": "always_allow"
+          }
         }
       ]
     },
@@ -40,7 +46,10 @@
       "configs": [
         {
           "name": "get_issue",
-          "enabled": true
+          "enabled": true,
+          "permission_policy": {
+            "type": "always_allow"
+          }
         }
       ]
     }

--- a/mintlify/reference/cli.mdx
+++ b/mintlify/reference/cli.mdx
@@ -308,6 +308,8 @@ Every MCP server named by a tool's `mcp://<server>/<tool>` URI needs an endpoint
 
 Kastor stamps `metadata.kastor_managed = "<block address>"` on every agent it creates and refuses to compare a remote agent that does not carry the marker, so an agent created by hand in the Console cannot be overwritten by an apply.
 
+Declaring a tool is the grant. If `agent.x` lists `tool.y`, kastor sets that tool's permission policy to `always_allow` on the remote agent, so the deployed agent can call every tool it declares without a trip to the Console. The permission is part of the compared object: flipping a tool to deny in the Console shows up in `kastor plan` as drift, and `kastor apply` sets it back. The policy is not configurable in the spec yet — every declared tool is allowed.
+
 The Managed Agents resource is narrower than the Kastor agent block, and fields that are meaningless for a target are errors rather than silently ignored:
 
 | Spec | Result on `claude_agents` |


### PR DESCRIPTION
Agents applied to Claude Managed Agents came up with every MCP tool denied: apply reported success, plan reported no drift, and the deployed agent could not call a tool it declared. The provider created the agent without stating a per-tool permission, so the platform's own default for an unset permission won.

Declaring a tool in the spec is the grant. Create now sets permission_policy to always_allow on every tool in the agent closure, the permission is part of the neutral compared object so a console-side change away from the grant reads as drift, and update reconciles it back to the spec.

The golden API response fixture omitted the per-tool permission the API always returns, which is why no test saw this; it now carries it.

Making the policy configurable in the spec is KAS-62's design pass, noted at the call site.

The live acceptance run gains a session step: it asks the deployed agent to call its MCP tool and asserts the platform evaluated the call as allow. A permission that is stored but ignored is invisible to every CRUD assertion. Two things the first live run taught the test itself:

  - always_deny is not a value managed-agents-2026-04-01 accepts (400, `"always_deny" is not a valid value`), so the out-of-band edit uses always_ask — the only policy that is not the grant. The rejection is recorded at the constant so nobody retries deny.
  - The session step needs a tool the configured MCP server actually serves; one it does not serve is never offered to the model, so the turn makes no tool call and proves nothing. KASTOR_MCP_ACCEPTANCE_TOOL names it.