### PR TITLE
Add explicit target plugins and protocol v1 (KAS-76, KAS-77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ v0 exit criteria KAS-36 are met.
 
 ### Added
 
+- Explicit target plugin requirements and selectors (KAS-76)
+
+  Project files can declare `kastor.required_plugins` entries with stable
+  source and version coordinates, and each target can select one with
+  `plugin`. Target labels are now instance identity rather than implementation
+  selection. Target-specific settings live in an opaque `config` block owned
+  by the selected plugin; core parsing and module validation no longer contain
+  LangGraph, eve, or Claude capability matrices. Existing v0.2 label-based
+  targets remain temporary CLI aliases, while legacy target `auth` and
+  top-level `vault_id` receive migration errors.
+
 - `requires_approval` on agent blocks (KAS-66)
 
   `tools` remains the grant; `requires_approval = [tool.x]` narrows granted
@@ -48,7 +59,7 @@ v0 exit criteria KAS-36 are met.
   display name is nullable and non-unique on the platform) but output should
   still be readable.
 
-- `mcp_server` blocks, credential references, and `vault_id` (KAS-63)
+- `mcp_server` blocks, credential references, and `config.vault_id` (KAS-63)
 
   `mcp://<server>/<tool>` now resolves against a declared `mcp_server` block, so
   an unknown server is a compile error instead of a run-time failure. Servers
@@ -56,8 +67,8 @@ v0 exit criteria KAS-36 are met.
   whose `ref` names *where* a credential lives (`env://NAME` or
   `connection://<credential_id>`) — never its value. `auth` blocks may be bound
   per target, which is what lets one server be authenticated on both the codegen
-  and the platform path. `target "claude_agents"` gains `vault_id`, read only by
-  `doctor`.
+  and the platform path. The Anthropic plugin's target config gains `vault_id`,
+  read only by `doctor`.
 
 - The `langgraph` target generates `mcp_servers.json` from the module's
   `mcp_server` blocks (KAS-65)

--- a/README.md
+++ b/README.md
@@ -580,6 +580,32 @@ go install github.com/weirdGuy/kastor/cmd/kastor@latest
 
 Or download an archive for your platform from the [releases page](https://github.com/weirdGuy/kastor/releases), verify it against `checksums.txt`, and put the `kastor` binary on your PATH.
 
+### Install target plugins
+
+An explicit target starts a separate executable whose name is the last segment
+of its source address. For the official plugins those binaries are
+`kastor-langgraph`, `kastor-eve`, and `kastor-anthropic`.
+
+Until tagged plugin releases and automatic plugin installation are available,
+build the needed repository and put the binary on your `PATH`:
+
+```sh
+git clone https://github.com/getkastordev/kastor-langgraph
+cd kastor-langgraph
+go build -o ~/.local/bin/kastor-langgraph ./cmd/kastor-langgraph
+```
+
+Discovery order is:
+
+1. `KASTOR_PLUGIN_<LOCAL_NAME>` — an exact executable path, such as
+   `KASTOR_PLUGIN_LANGGRAPH=/work/kastor-langgraph`.
+2. `KASTOR_PLUGIN_DIR` — a directory containing source-named executables.
+3. `PATH`.
+
+The core performs a protocol, source-identity, target-kind, and version
+handshake before sending the canonical module IR. Plugin stdout is reserved
+for protocol traffic; diagnostics and logs belong on stderr.
+
 ## Development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Write a module — one project file, one agent, two tools, one prompt:
 kastor {
   required_plugins {
     anthropic = {
-      source  = "github.com/getkastor/kastor-anthropic"
+      source  = "github.com/getkastordev/kastor-anthropic"
       version = "~> 0.1"
     }
   }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Kastor is a source-of-truth layer for AI agents.**
 
-Define agents, tools, prompts, models, and targets in HCL. Validate the spec. Compile it to runnable framework code, or reconcile hosted agents with Terraform-style `plan` / `apply` / `state`.
+Define agents, tools, prompts, models, and plugin-backed targets in HCL. Validate the spec. Compile it to runnable framework code, or reconcile hosted agents with Terraform-style `plan` / `apply` / `state`.
 
 ```sh
 kastor validate examples/weather
@@ -26,10 +26,11 @@ Working today:
 - scaffold a new module with `kastor init`
 - parse `.agent`, `.tool`, `.prompt`, and `kastor.hcl`
 - validate references and prompt variables
+- declare versioned target plugins separately from target instances
 - build runnable LangGraph and eve projects
 - require human approval for selected tools, portably across LangGraph, eve, and Claude Managed Agents
 - run `kastor plan` / `kastor apply` / `kastor destroy` against the built-in in-memory platform
-- reconcile hosted [Claude Managed Agents](#quickstart-hosted-claude-agents) with `target "claude_agents"`
+- reconcile hosted [Claude Managed Agents](#quickstart-hosted-claude-agents) through the Anthropic target plugin
 - local state file, three-way diffs, and drift detection
 - [VS Code syntax highlighting and file icons](#vs-code-support)
 - examples: [weather agent](examples/weather), [content scheduler](examples/scheduler), [support triage](examples/support-triage)
@@ -59,7 +60,9 @@ framework code      hosted agents
 (LangGraph, eve)    (Claude Managed Agents)
 ```
 
-Kastor has two paths:
+Kastor has two paths. Targets choose an implementation explicitly through
+`kastor.required_plugins`; their labels remain ordinary module-local instance
+names:
 
 - `kastor build` compiles a Kastor module into runnable framework code.
 - `kastor plan` / `kastor apply` reconciles long-lived hosted agents with state, diffs, and drift detection.
@@ -185,8 +188,9 @@ Three things worth knowing:
 
 ## Quickstart: hosted Claude agents
 
-This is the hosted path: `target "claude_agents"` reconciles agents in your
-Anthropic organization through Claude Managed Agents. Unlike `memory`, `apply`
+This is the hosted path: a platform target selecting the Anthropic plugin
+reconciles agents in your Anthropic organization through Claude Managed Agents.
+Unlike the memory plugin, `apply`
 here creates real remote objects, and `destroy` **archives them irreversibly** —
 read [Destroying a Claude agent](#destroying-a-claude-agent) before you run it.
 
@@ -199,18 +203,28 @@ Write a module — one project file, one agent, two tools, one prompt:
 
 ```hcl
 # kastor.hcl
+kastor {
+  required_plugins {
+    anthropic = {
+      source  = "github.com/getkastor/kastor-anthropic"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "haiku" {
   provider = "anthropic"
   id       = "claude-haiku-4-5"
 }
 
 target "claude_agents" {
-  type     = "platform"
-  vault_id = "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+	type   = "platform"
+	plugin = "anthropic"
 
-  auth {
-    api_key_env = "ANTHROPIC_API_KEY"
-  }
+	config {
+		api_key_env = "ANTHROPIC_API_KEY"
+		vault_id    = "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+	}
 }
 
 # The MCP server tool.tavily_search binds to. Declaring it is what makes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,7 +117,8 @@ covers is the remote read and the tool-permission check against a real agent
 object — the credential path is covered offline against the fake vault, since
 exercising it live would mean creating and expiring a real vault credential per
 run. If you have a vault to hand, the fuller manual check is worth one pass:
-add `vault_id` and a `connection://` ref to the copied module, run `doctor`
+add `vault_id` inside the Anthropic target's `config` block and a
+`connection://` ref to the copied module, run `doctor`
 before authorizing the connection (expect `✗`, exit 1), authorize it and re-run
 (expect exit 0), then re-run with the vault host blocked (expect `? could not
 verify`, never "does not exist").

--- a/SPEC.md
+++ b/SPEC.md
@@ -380,6 +380,11 @@ target "production" {
   an omitted selector is accepted as a deprecated compatibility form and the
   target label is resolved through the legacy in-process adapter. New modules
   and generated scaffolds always use the explicit form.
+- Explicit plugins are executable processes. Core resolves the binary from a
+  local-name override, the configured plugin directory, or `PATH`; performs a
+  protocol/source/version/kind handshake; and delegates validation plus the
+  target operation over the versioned protocol. The final source path segment
+  is the default executable name.
 - A target's label is only its module-local instance identity. Multiple target
   blocks may select the same plugin with different output paths or config.
 - `type` is a closed enum: `codegen` or `platform`. Unknown values are a compile error; new target types are additive spec changes.
@@ -388,7 +393,7 @@ target "production" {
   plugin. Core preserves it as a JSON-compatible value tree and has no
   provider-specific fields. Unknown or meaningless config entries are plugin
   errors rather than silently ignored values.
-- The memory plugin is an **ephemeral in-memory store** for examples,
+- The built-in memory target is an **ephemeral in-memory store** for examples,
   onboarding, and CI. It accepts no config. Its remote objects die with the
   process, so a later invocation truthfully reports remote-missing drift.
 - The Anthropic plugin accepts `api_key_env` and `vault_id` in `config`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -341,11 +341,11 @@ source and version separately from target instances:
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
     anthropic = {
-      source  = "github.com/getkastor/kastor-anthropic"
+      source  = "github.com/getkastordev/kastor-anthropic"
       version = "~> 0.1"
     }
   }

--- a/SPEC.md
+++ b/SPEC.md
@@ -333,33 +333,69 @@ No model, no IO — prompts are pure templates (per decision #2).
 - The body is everything after the closing delimiter line, preserved byte for byte.
 
 ### 3.5 `target` (project file)
- 
-Where the spec goes. Two categories mirror the two verbs:
- 
+
+Target implementations are external plugins. A module declares their stable
+source and version separately from target instances:
+
 ```hcl
-# Codegen target → `kastor build`
-target "langgraph" {
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+    anthropic = {
+      source  = "github.com/getkastor/kastor-anthropic"
+      version = "~> 0.1"
+    }
+  }
+}
+
+# Codegen target instance → `kastor build`
+target "python" {
   type   = "codegen"
+  plugin = "langgraph"
   output = "./gen/langgraph"
 }
- 
-# Managed platform target → `kastor plan` / `kastor apply`
-target "claude_agents" {
-  type = "platform"
-  auth {
+
+# Managed platform target instance → `kastor plan` / `kastor apply`
+target "production" {
+  type   = "platform"
+  plugin = "anthropic"
+
+  config {
     api_key_env = "ANTHROPIC_API_KEY"
+    vault_id    = "vlt_011CZkZDLs7fYzm1hXNPeRjv"
   }
 }
 ```
 
 **Rules:**
+- `kastor.required_plugins` maps a module-local name to a stable `source` and a
+  version constraint. Both strings are required and unknown fields are errors.
+  The local name is configuration syntax only; installation and state identity
+  use the source plus the selected locked version.
+- `target.plugin` names one entry in `required_plugins`. A missing entry is a
+  compile error listing the declared plugins. During the v0.2 migration window,
+  an omitted selector is accepted as a deprecated compatibility form and the
+  target label is resolved through the legacy in-process adapter. New modules
+  and generated scaffolds always use the explicit form.
+- A target's label is only its module-local instance identity. Multiple target
+  blocks may select the same plugin with different output paths or config.
 - `type` is a closed enum: `codegen` or `platform`. Unknown values are a compile error; new target types are additive spec changes.
-- `codegen` targets require `output` and do not allow `auth`.
-- `platform` targets do not allow `output`; `auth` is optional (ambient credentials — env vars, instance roles — are the common case).
-- Fields that are meaningless for a target's type are errors, not ignored (configs rot through silent acceptance).
-- **A platform target's label selects its provider implementation**, exactly as a codegen target's label selects its generator: `target "claude_agents"` binds to the Claude Managed Agents reconciler, `target "memory"` to the built-in in-memory platform. A label with no registered provider is an error naming the available providers. (A separate `provider` attribute is deliberately deferred until something forces it — e.g. two targets on the same platform kind in one module.) A target's label is also how a tool's `source` block names it (§3.3).
-- The `memory` platform is built in: an **ephemeral in-memory store** so plan/apply can be demonstrated and exercised — examples, onboarding, CI — with no credentials and no network. `auth` on it is an error (meaningless fields, again). Its remote objects die with the process, so a later invocation's plan truthfully reports previously applied resources as remote-missing drift.
-- A `claude_agents` target may declare `vault_id` — the id of the Anthropic vault (`vlt_…`) holding the credentials its MCP servers reference. It is **required** when any `mcp_server` bound on this target carries a `connection://` auth ref (§3.6), and an error on every other target, `memory` and codegen targets alike (meaningless fields, again). It names a location, not a secret: the vault's contents are created and rotated outside kastor, and the only command that reads it is `kastor doctor` (§5.3), which reads enough to verify a reference resolves and never the credential's value. `plan` and `apply` never contact it.
+- `codegen` targets require `output`. `platform` targets do not allow it.
+- `config` is an optional literal-only map owned and validated by the selected
+  plugin. Core preserves it as a JSON-compatible value tree and has no
+  provider-specific fields. Unknown or meaningless config entries are plugin
+  errors rather than silently ignored values.
+- The memory plugin is an **ephemeral in-memory store** for examples,
+  onboarding, and CI. It accepts no config. Its remote objects die with the
+  process, so a later invocation truthfully reports remote-missing drift.
+- The Anthropic plugin accepts `api_key_env` and `vault_id` in `config`.
+  `vault_id` is required when an MCP server bound to that target uses a
+  `connection://` reference. It names a location, not a secret; only plugin
+  readiness checks read enough to verify the reference. Plan and apply never
+  read credential values.
 
 ### 3.6 `mcp_server` (project file)
 
@@ -439,7 +475,7 @@ mcp_server "hubspot" {
 
 **On `claude_agents`, `connection://` is verified by `kastor doctor`** (§5.3),
 not by `plan`. The ref names a credential **id** in the vault the target declares
-(`vault_id`, §3.5) — not a display name, which the platform allows to be absent
+(`config.vault_id`, §3.5) — not a display name, which the platform allows to be absent
 and to repeat. `doctor` fetches it and reports a finding if it does not exist, if
 it is archived, or if the credential's own MCP server URL does not equal this
 block's `url`. So a typo'd, archived, or misdirected credential is named by a

--- a/cmd/kastor/apply.go
+++ b/cmd/kastor/apply.go
@@ -53,7 +53,7 @@ func newDestroyCmd() *cobra.Command {
 // operation; state write failures are IO errors (exit 2), and the engine's
 // error already tells the user what was applied before the failure.
 func runApply(ctx context.Context, stdout, stderr io.Writer, dir, targetName string, destroy bool) error {
-	jobs, release, err := preparePlatform(stderr, dir, targetName)
+	jobs, release, err := preparePlatform(ctx, stderr, dir, targetName)
 	if err != nil {
 		return err
 	}

--- a/cmd/kastor/build.go
+++ b/cmd/kastor/build.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -15,17 +16,15 @@ import (
 	"github.com/weirdGuy/kastor/internal/build/langgraph"
 	"github.com/weirdGuy/kastor/internal/graph"
 	"github.com/weirdGuy/kastor/internal/module"
+	pluginruntime "github.com/weirdGuy/kastor/internal/plugin"
 	"github.com/weirdGuy/kastor/internal/schema"
 )
 
-// generators is the temporary in-process adapter for codegen plugins. Stable
-// source addresses drive explicit targets; short keys preserve v0.2 modules
-// until the executable plugin protocol replaces this registry (KAS-77).
+// generators contains only the v0.2 compatibility implementations. Targets
+// with explicit plugin selectors always execute the declared binary.
 var generators = map[string]build.Generator{
-	"eve":                 eve.Generator{},
-	evePluginSource:       eve.Generator{},
-	"langgraph":           langgraph.Generator{},
-	langgraphPluginSource: langgraph.Generator{},
+	"eve":       eve.Generator{},
+	"langgraph": langgraph.Generator{},
 }
 
 func newBuildCmd() *cobra.Command {
@@ -40,7 +39,7 @@ func newBuildCmd() *cobra.Command {
 			if len(args) == 1 {
 				dir = args[0]
 			}
-			return runBuild(cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, target)
+			return runBuild(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, target)
 		},
 	}
 	cmd.Flags().StringVar(&target, "target", "", "build only the named codegen target (default: all codegen targets)")
@@ -61,8 +60,8 @@ func usageMaxArgs(n int) cobra.PositionalArgs {
 // selected codegen targets in order, stopping at the first failure. Output
 // already synced for earlier targets stays in place — every target's sync is
 // independently complete or untouched.
-func runBuild(stdout, stderr io.Writer, dir, targetName string) error {
-	mod, g, err := compileModule(stderr, dir)
+func runBuild(ctx context.Context, stdout, stderr io.Writer, dir, targetName string) error {
+	mod, g, err := compileModule(ctx, stderr, dir)
 	if err != nil {
 		return err
 	}
@@ -73,7 +72,7 @@ func runBuild(stdout, stderr io.Writer, dir, targetName string) error {
 	}
 
 	for _, tgt := range targets {
-		if err := buildTarget(stdout, stderr, mod, g, tgt); err != nil {
+		if err := buildTarget(ctx, stdout, stderr, mod, g, tgt); err != nil {
 			return err
 		}
 	}
@@ -114,21 +113,43 @@ func selectTargets(mod *module.Module, name string) ([]*schema.Target, error) {
 // buildTarget generates one codegen target and syncs the files into its
 // output directory. Generation failures keep the default exit code 1
 // (codegen errors); sync failures are IO errors, exit 2.
-func buildTarget(stdout, stderr io.Writer, mod *module.Module, g *graph.Graph, tgt *schema.Target) error {
-	source, err := targetPluginSource(mod, tgt)
-	if err != nil {
-		return err
-	}
-	gen, ok := generators[source]
-	if !ok {
-		return fmt.Errorf("%s: no code generator installed for plugin %q (available: %s)", tgt.Addr(), source, strings.Join(generatorNames(), ", "))
+func buildTarget(ctx context.Context, stdout, stderr io.Writer, mod *module.Module, g *graph.Graph, tgt *schema.Target) error {
+	var gen build.Generator
+	if tgt.Plugin == "" {
+		source, err := targetPluginSource(mod, tgt)
+		if err != nil {
+			return err
+		}
+		var ok bool
+		gen, ok = generators[source]
+		if !ok {
+			return fmt.Errorf("%s: no code generator installed for legacy target %q (available: %s)", tgt.Addr(), source, strings.Join(generatorNames(), ", "))
+		}
+	} else {
+		client, err := openTargetPlugin(ctx, mod, tgt)
+		if err != nil {
+			return err
+		}
+		gen = &pluginruntime.Codegen{Client: client, Context: ctx}
+		files, generateErr := build.Run(gen, &build.Job{Module: mod, Graph: g, Target: tgt})
+		closeErr := client.Close()
+		if generateErr != nil {
+			return generateErr
+		}
+		if closeErr != nil {
+			return fmt.Errorf("%s: close plugin: %w", tgt.Addr(), closeErr)
+		}
+		return writeGeneratedTarget(stdout, stderr, mod, tgt, files)
 	}
 
 	files, err := build.Run(gen, &build.Job{Module: mod, Graph: g, Target: tgt})
 	if err != nil {
 		return err
 	}
+	return writeGeneratedTarget(stdout, stderr, mod, tgt, files)
+}
 
+func writeGeneratedTarget(stdout, stderr io.Writer, mod *module.Module, tgt *schema.Target, files []build.File) error {
 	outDir, err := build.OutputDir(mod, tgt)
 	if err != nil {
 		return err

--- a/cmd/kastor/build.go
+++ b/cmd/kastor/build.go
@@ -18,14 +18,14 @@ import (
 	"github.com/weirdGuy/kastor/internal/schema"
 )
 
-// generators maps a codegen target's name to its framework generator: the
-// target label doubles as the framework selector (SPEC.md §3.5 has no
-// separate framework attribute). A codegen target whose name has no entry
-// here is a codegen error at build time, not a validation error — the block
-// itself is valid spec.
+// generators is the temporary in-process adapter for codegen plugins. Stable
+// source addresses drive explicit targets; short keys preserve v0.2 modules
+// until the executable plugin protocol replaces this registry (KAS-77).
 var generators = map[string]build.Generator{
-	"eve":       eve.Generator{},
-	"langgraph": langgraph.Generator{},
+	"eve":                 eve.Generator{},
+	evePluginSource:       eve.Generator{},
+	"langgraph":           langgraph.Generator{},
+	langgraphPluginSource: langgraph.Generator{},
 }
 
 func newBuildCmd() *cobra.Command {
@@ -115,9 +115,13 @@ func selectTargets(mod *module.Module, name string) ([]*schema.Target, error) {
 // output directory. Generation failures keep the default exit code 1
 // (codegen errors); sync failures are IO errors, exit 2.
 func buildTarget(stdout, stderr io.Writer, mod *module.Module, g *graph.Graph, tgt *schema.Target) error {
-	gen, ok := generators[tgt.Name]
+	source, err := targetPluginSource(mod, tgt)
+	if err != nil {
+		return err
+	}
+	gen, ok := generators[source]
 	if !ok {
-		return fmt.Errorf("%s: no code generator named %q (available: %s)", tgt.Addr(), tgt.Name, strings.Join(generatorNames(), ", "))
+		return fmt.Errorf("%s: no code generator installed for plugin %q (available: %s)", tgt.Addr(), source, strings.Join(generatorNames(), ", "))
 	}
 
 	files, err := build.Run(gen, &build.Job{Module: mod, Graph: g, Target: tgt})

--- a/cmd/kastor/build_test.go
+++ b/cmd/kastor/build_test.go
@@ -323,6 +323,7 @@ func TestBuildCommandDefaultsToCwd(t *testing.T) {
 // plan/apply, and the reported file count matches what lands on disk in the
 // declared output directory.
 func TestBuildCommandWeatherExample(t *testing.T) {
+	langgraphClient, eveClient := useFakeCodegenPlugins(t)
 	dir := copyModule(t, filepath.Join("..", "..", "examples", "weather"))
 	out, err := runBuildCmd(t, dir)
 	if err != nil {
@@ -349,6 +350,12 @@ func TestBuildCommandWeatherExample(t *testing.T) {
 	// reported count (hidden entries are the user's and excluded).
 	if onDisk := countVisibleFiles(t, outDir); reported != onDisk {
 		t.Errorf("reported %d files, found %d on disk", reported, onDisk)
+	}
+	for name, client := range map[string]*fakePluginClient{"langgraph": langgraphClient, "eve": eveClient} {
+		if client.validateCalls != 1 || client.generateCalls != 1 || client.closeCalls != 2 {
+			t.Errorf("%s protocol calls: validate=%d generate=%d close=%d; want 1, 1, 2",
+				name, client.validateCalls, client.generateCalls, client.closeCalls)
+		}
 	}
 }
 
@@ -399,6 +406,7 @@ func TestBuildCommandCountIgnoresUserArtifacts(t *testing.T) {
 // reaches the user through a sidecar and a warning instead of overwriting the
 // implementation — once, not on every build after.
 func TestBuildCommandKeepsRuntimeImplementation(t *testing.T) {
+	useFakeCodegenPlugins(t)
 	dir := copyModule(t, filepath.Join("..", "..", "examples", "scheduler"))
 	if out, err := runBuildCmd(t, dir); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out)

--- a/cmd/kastor/claude_acceptance_test.go
+++ b/cmd/kastor/claude_acceptance_test.go
@@ -72,9 +72,9 @@ func TestClaudeManagedAgentsAcceptance(t *testing.T) {
 	}
 
 	realProvider, err := realFactory(&schema.Target{
-		Name: claudeAcceptanceTarget,
-		Type: "platform",
-		Auth: &schema.Auth{APIKeyEnv: "ANTHROPIC_API_KEY"},
+		Name:   claudeAcceptanceTarget,
+		Type:   "platform",
+		Config: map[string]any{"api_key_env": "ANTHROPIC_API_KEY"},
 	})
 	if err != nil {
 		t.Fatalf("construct real Claude provider: %v", err)

--- a/cmd/kastor/doctor.go
+++ b/cmd/kastor/doctor.go
@@ -37,7 +37,7 @@ func newDoctorCmd() *cobra.Command {
 }
 
 func runDoctor(ctx context.Context, stdout, stderr io.Writer, dir, targetName string) error {
-	jobs, release, err := preparePlatform(stderr, dir, targetName)
+	jobs, release, err := preparePlatform(ctx, stderr, dir, targetName)
 	if err != nil {
 		return err
 	}

--- a/cmd/kastor/doctor_test.go
+++ b/cmd/kastor/doctor_test.go
@@ -30,7 +30,7 @@ func readStateFile(t *testing.T, dir string) string {
 }
 
 // registerVaultFake wires a fake with a credential vault under the
-// claude_agents target label, replacing the real provider factory for the
+// legacy claude_agents target alias, replacing the real provider factory for the
 // duration of the test so doctor is exercised end to end without network.
 func registerVaultFake(t *testing.T, credentials map[string]providertest.Credential) *providertest.VaultFake {
 	t.Helper()

--- a/cmd/kastor/external_plugins_test.go
+++ b/cmd/kastor/external_plugins_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	corebuild "github.com/weirdGuy/kastor/internal/build"
+	"github.com/weirdGuy/kastor/internal/build/eve"
+	"github.com/weirdGuy/kastor/internal/build/langgraph"
+	"github.com/weirdGuy/kastor/internal/module"
+	pluginruntime "github.com/weirdGuy/kastor/internal/plugin"
+	"github.com/weirdGuy/kastor/internal/schema"
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
+)
+
+type fakePluginClient struct {
+	metadata      protocol.Metadata
+	validateCalls int
+	generateCalls int
+	diffCalls     int
+	closeCalls    int
+}
+
+func newFakePluginClient(source string, kind protocol.Kind) *fakePluginClient {
+	return &fakePluginClient{metadata: protocol.Metadata{
+		Protocol: protocol.Version,
+		Source:   source,
+		Version:  "0.1.0",
+		Kinds:    []protocol.Kind{kind},
+	}}
+}
+
+func useFakePlugins(t *testing.T, clients ...*fakePluginClient) {
+	t.Helper()
+	bySource := map[string]*fakePluginClient{}
+	for _, client := range clients {
+		bySource[client.metadata.Source] = client
+	}
+	previous := openPlugin
+	openPlugin = func(_ context.Context, localName string, requirement *schema.PluginRequirement) (pluginruntime.Client, error) {
+		client := bySource[requirement.Source]
+		if client == nil {
+			return nil, fmt.Errorf("plugin.%s: no test plugin for %q", localName, requirement.Source)
+		}
+		return client, nil
+	}
+	t.Cleanup(func() { openPlugin = previous })
+}
+
+func useFakeCodegenPlugins(t *testing.T) (*fakePluginClient, *fakePluginClient) {
+	t.Helper()
+	langgraphClient := newFakePluginClient(langgraphPluginSource, protocol.KindCodegen)
+	eveClient := newFakePluginClient(evePluginSource, protocol.KindCodegen)
+	useFakePlugins(t, langgraphClient, eveClient)
+	return langgraphClient, eveClient
+}
+
+func (c *fakePluginClient) Metadata() protocol.Metadata { return c.metadata }
+
+func (c *fakePluginClient) Validate(_ context.Context, request *protocol.ValidateRequest) (*protocol.ValidateResponse, error) {
+	c.validateCalls++
+	return validateLikeOfficialPlugin(c.metadata.Source, request), nil
+}
+
+func (c *fakePluginClient) Generate(_ context.Context, request *protocol.GenerateRequest) (*protocol.GenerateResponse, error) {
+	c.generateCalls++
+	mod, target := moduleFromProtocol(request.Module, request.Target)
+	var generator corebuild.Generator
+	switch c.metadata.Source {
+	case langgraphPluginSource:
+		generator = langgraph.Generator{}
+	case evePluginSource:
+		generator = eve.Generator{}
+	default:
+		return nil, fmt.Errorf("no test generator for %q", c.metadata.Source)
+	}
+	files, err := generator.Generate(&corebuild.Job{Module: mod, Target: target})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]protocol.File, len(files))
+	for i, file := range files {
+		result[i] = protocol.File{Path: file.Path, Data: file.Data, Preserve: file.Preserve}
+	}
+	return &protocol.GenerateResponse{Files: result}, nil
+}
+
+func (c *fakePluginClient) Read(context.Context, *protocol.ReadRequest) (*protocol.ReadResponse, error) {
+	return &protocol.ReadResponse{}, nil
+}
+
+func (c *fakePluginClient) Create(context.Context, *protocol.CreateRequest) (*protocol.CreateResponse, error) {
+	return &protocol.CreateResponse{ID: "fake-id"}, nil
+}
+
+func (c *fakePluginClient) Update(context.Context, *protocol.UpdateRequest) error { return nil }
+func (c *fakePluginClient) Delete(context.Context, *protocol.DeleteRequest) error { return nil }
+
+func (c *fakePluginClient) Diff(context.Context, *protocol.DiffRequest) (*protocol.DiffResponse, error) {
+	c.diffCalls++
+	return &protocol.DiffResponse{}, nil
+}
+
+func (c *fakePluginClient) Check(context.Context, *protocol.CheckRequest) (*protocol.CheckResponse, error) {
+	return &protocol.CheckResponse{}, nil
+}
+
+func (c *fakePluginClient) Close() error {
+	c.closeCalls++
+	return nil
+}
+
+func validateLikeOfficialPlugin(source string, request *protocol.ValidateRequest) *protocol.ValidateResponse {
+	if request == nil || request.Module == nil || request.Target == nil {
+		return &protocol.ValidateResponse{Diagnostics: []protocol.Diagnostic{externalDiagnostic("", "incomplete validation request", "")}}
+	}
+	target := request.Target
+	referenced := map[string]bool{}
+	for _, tool := range request.Module.Tools {
+		if tool.Source == nil || tool.Source.Kind != "mcp" {
+			continue
+		}
+		server, _, err := protocol.ParseMCPURI(tool.Source.URI)
+		if err == nil {
+			referenced[server] = true
+		}
+	}
+
+	var diagnostics []protocol.Diagnostic
+	keys := make([]string, 0, len(target.Config))
+	for key := range target.Config {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if source != claudePluginSource || (key != "api_key_env" && key != "vault_id") {
+			diagnostics = append(diagnostics, externalDiagnostic(target.Addr(), "unsupported config attribute", key))
+			continue
+		}
+		if _, ok := target.Config[key].(string); !ok {
+			diagnostics = append(diagnostics, externalDiagnostic(target.Addr(), "config attribute must be a string", key))
+		}
+	}
+
+	for _, server := range request.Module.MCPServers {
+		if !referenced[server.Name] {
+			continue
+		}
+		if server.Transport == "stdio" && source != langgraphPluginSource {
+			detail := "Eve connections require an HTTP endpoint"
+			if source == claudePluginSource {
+				detail = "Claude Managed Agents requires an HTTP endpoint"
+			}
+			diagnostics = append(diagnostics, externalDiagnostic(server.Addr(), "stdio transport is not supported", detail))
+		}
+		auth, ok := server.AuthFor(target.Addr())
+		if !ok {
+			continue
+		}
+		scheme, _, err := protocol.ParseCredentialRef(auth.Ref)
+		if err != nil {
+			continue
+		}
+		wantScheme := protocol.SchemeEnv
+		if source == claudePluginSource {
+			wantScheme = protocol.SchemeConnection
+		}
+		if scheme != wantScheme {
+			diagnostics = append(diagnostics, externalDiagnostic(server.Addr(), "unsupported credential scheme", scheme+"://"))
+			continue
+		}
+		if source == claudePluginSource && scheme == protocol.SchemeConnection {
+			vault, ok := target.ConfigString("vault_id")
+			if !ok || vault == "" {
+				diagnostics = append(diagnostics, externalDiagnostic(target.Addr(), "vault_id is required for connection credentials", auth.Ref))
+			}
+		}
+	}
+	return &protocol.ValidateResponse{Diagnostics: diagnostics}
+}
+
+func externalDiagnostic(addr, summary, detail string) protocol.Diagnostic {
+	return protocol.Diagnostic{Severity: protocol.SeverityError, Addr: addr, Summary: summary, Detail: detail}
+}
+
+func moduleFromProtocol(input *protocol.Module, selected *protocol.Target) (*module.Module, *schema.Target) {
+	mod := &module.Module{}
+	for _, model := range input.Models {
+		mod.Models = append(mod.Models, &schema.Model{Name: model.Name, Provider: model.Provider, ID: model.ID, Params: model.Params})
+	}
+	for _, prompt := range input.Prompts {
+		mod.Prompts = append(mod.Prompts, &schema.Prompt{Name: prompt.Name, Requires: prompt.Requires, Body: prompt.Body, Vars: prompt.Vars})
+	}
+	for _, tool := range input.Tools {
+		converted := &schema.Tool{Name: tool.Name, Description: tool.Description}
+		for _, param := range tool.Params {
+			converted.Params = append(converted.Params, &schema.ToolParam{Name: param.Name, Type: param.Type, Description: param.Description, Default: param.Default})
+		}
+		if tool.Returns != nil {
+			converted.Returns = &schema.ToolReturns{Type: tool.Returns.Type}
+		}
+		if tool.Source != nil {
+			converted.Source = &schema.ToolSource{Kind: tool.Source.Kind, URI: tool.Source.URI}
+		}
+		mod.Tools = append(mod.Tools, converted)
+	}
+	for _, agent := range input.Agents {
+		converted := &schema.Agent{
+			Name: agent.Name, Description: agent.Description, Model: agent.Model,
+			SystemPrompt: agent.SystemPrompt, Tools: agent.Tools,
+			RequiresApproval: agent.RequiresApproval, DependsOn: agent.DependsOn,
+		}
+		for _, item := range agent.Inputs {
+			converted.Inputs = append(converted.Inputs, &schema.AgentInput{
+				Name: item.Name, Type: item.Type, Description: item.Description,
+				Optional: item.Optional, Default: item.Default, DefaultRef: item.DefaultRef,
+			})
+		}
+		for _, item := range agent.Outputs {
+			converted.Outputs = append(converted.Outputs, &schema.AgentOutput{Name: item.Name, Type: item.Type, Description: item.Description})
+		}
+		mod.Agents = append(mod.Agents, converted)
+	}
+	for _, server := range input.MCPServers {
+		converted := &schema.MCPServer{
+			Name: server.Name, Transport: server.Transport, URL: server.URL,
+			Command: server.Command, Args: server.Args,
+		}
+		for _, auth := range server.Auth {
+			converted.Auth = append(converted.Auth, &schema.MCPAuth{Ref: auth.Ref, Targets: auth.Targets})
+		}
+		mod.MCPServers = append(mod.MCPServers, converted)
+	}
+	for _, target := range input.Targets {
+		mod.Targets = append(mod.Targets, &schema.Target{
+			Name: target.Name, Type: target.Type, Plugin: target.Plugin,
+			Output: target.Output, Config: target.Config,
+		})
+	}
+	return mod, &schema.Target{
+		Name: selected.Name, Type: selected.Type, Plugin: selected.Plugin,
+		Output: selected.Output, Config: selected.Config,
+	}
+}

--- a/cmd/kastor/init_test.go
+++ b/cmd/kastor/init_test.go
@@ -133,7 +133,7 @@ func TestInitCommandScaffoldWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("validate Execute() error = %v\noutput:\n%s", err, out)
 	}
-	if !strings.Contains(out, "1 agent, 1 tool, 1 prompt, 1 model, 1 target") {
+	if !strings.Contains(out, "1 agent, 1 tool, 1 prompt, 1 plugin, 1 model, 1 target") {
 		t.Errorf("validate output missing module summary:\n%s", out)
 	}
 

--- a/cmd/kastor/init_test.go
+++ b/cmd/kastor/init_test.go
@@ -115,6 +115,7 @@ func TestInitCommandErrors(t *testing.T) {
 // new directory, then the scaffolded module must pass kastor validate and
 // kastor build with zero edits, and be in canonical kastor fmt style.
 func TestInitCommandScaffoldWorks(t *testing.T) {
+	useFakeCodegenPlugins(t)
 	dir := filepath.Join(t.TempDir(), "demo") // init must create missing dirs
 	out, err := runCmd(t, "init", dir)
 	if err != nil {

--- a/cmd/kastor/plan.go
+++ b/cmd/kastor/plan.go
@@ -29,7 +29,7 @@ func newPlanCmd() *cobra.Command {
 }
 
 func runPlan(ctx context.Context, stdout, stderr io.Writer, dir, targetName string) error {
-	jobs, release, err := preparePlatform(stderr, dir, targetName)
+	jobs, release, err := preparePlatform(ctx, stderr, dir, targetName)
 	if err != nil {
 		return err
 	}

--- a/cmd/kastor/plan_test.go
+++ b/cmd/kastor/plan_test.go
@@ -164,9 +164,11 @@ func TestPlanApplyDestroyEndToEnd(t *testing.T) {
 
 // TestPlanWeatherExample is the issue #17 acceptance: a bare kastor plan on
 // examples/weather must produce a clean first plan against the built-in
-// memory platform — this output is the README demo. No fake registration:
-// it exercises the provider registry the shipped binary uses.
+// memory platform — this output is the README demo. Codegen plugins are faked
+// only for compile-time validation; the memory provider is the real built-in
+// registry entry the shipped binary uses.
 func TestPlanWeatherExample(t *testing.T) {
+	useFakeCodegenPlugins(t)
 	dir := copyModule(t, filepath.Join("..", "..", "examples", "weather"))
 	out, err := runCLI(t, "plan", dir)
 	if err != nil {

--- a/cmd/kastor/plan_test.go
+++ b/cmd/kastor/plan_test.go
@@ -227,8 +227,8 @@ func TestPlanRejectsUnappliableClaudeModule(t *testing.T) {
 target "claude_agents" {
   type = "platform"
 
-  auth {
-    api_key_env = "ANTHROPIC_API_KEY"
+	config {
+		api_key_env = "ANTHROPIC_API_KEY"
   }
 }
 `,
@@ -249,8 +249,8 @@ target "claude_agents" {
 target "claude_agents" {
   type = "platform"
 
-  auth {
-    api_key_env = "ANTHROPIC_API_KEY"
+	config {
+		api_key_env = "ANTHROPIC_API_KEY"
   }
 }
 `,
@@ -354,7 +354,7 @@ func TestPlatformCommandErrors(t *testing.T) {
 			args:     []string{"plan"},
 			dir:      "testdata/platform_memory_auth",
 			wantCode: 1,
-			wantOut:  []string{"target.memory", "auth block found", "in-memory platform takes no credentials"},
+			wantOut:  []string{"target.memory", `plugin "memory"`, `does not support config attribute "api_key_env"`},
 		},
 		{
 			name:     "invalid module never plans",

--- a/cmd/kastor/platform.go
+++ b/cmd/kastor/platform.go
@@ -14,12 +14,14 @@ import (
 	"github.com/weirdGuy/kastor/internal/state"
 )
 
-// providerFactories maps a platform target's name to its provider factory:
-// the target label doubles as the provider selector, exactly like codegen
-// target names select generators (see cmd/kastor/build.go).
+// providerFactories is the temporary in-process adapter for platform plugins.
+// Stable source addresses drive explicit targets; short keys preserve v0.2
+// modules until the executable plugin protocol replaces this registry.
 var providerFactories = map[string]func(*schema.Target) (provider.Provider, error){
-	"claude_agents": claude.Factory,
-	"memory":        memory.Factory,
+	"claude_agents":    claude.Factory,
+	claudePluginSource: claude.Factory,
+	"memory":           memory.Factory,
+	memoryPluginSource: memory.Factory,
 }
 
 // platformJob is one reconcile unit: a platform target with its resolved
@@ -46,7 +48,7 @@ func preparePlatform(stderr io.Writer, dir, targetName string) (jobs []*platform
 	// Resolve providers before locking: a missing provider needs no lock.
 	var resolved []*platformJob
 	for _, tgt := range targets {
-		p, err := providerFor(tgt)
+		p, err := providerFor(mod, tgt)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -112,11 +114,15 @@ func platformNames(mod *module.Module) []string {
 	return names
 }
 
-// providerFor resolves a platform target's provider from the registry.
-func providerFor(tgt *schema.Target) (provider.Provider, error) {
-	factory, ok := providerFactories[tgt.Name]
+// providerFor resolves a platform target's plugin through its declared source.
+func providerFor(mod *module.Module, tgt *schema.Target) (provider.Provider, error) {
+	source, err := targetPluginSource(mod, tgt)
+	if err != nil {
+		return nil, err
+	}
+	factory, ok := providerFactories[source]
 	if !ok {
-		return nil, fmt.Errorf("%s: no platform provider named %q (available: %s)", tgt.Addr(), tgt.Name, joinOrNone(providerNames()))
+		return nil, fmt.Errorf("%s: no platform provider installed for plugin %q (available: %s)", tgt.Addr(), source, joinOrNone(providerNames()))
 	}
 	p, err := factory(tgt)
 	if err != nil {

--- a/cmd/kastor/platform.go
+++ b/cmd/kastor/platform.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 
 	"github.com/weirdGuy/kastor/internal/module"
+	pluginruntime "github.com/weirdGuy/kastor/internal/plugin"
 	"github.com/weirdGuy/kastor/internal/provider"
 	"github.com/weirdGuy/kastor/internal/provider/claude"
 	"github.com/weirdGuy/kastor/internal/provider/memory"
@@ -14,14 +17,11 @@ import (
 	"github.com/weirdGuy/kastor/internal/state"
 )
 
-// providerFactories is the temporary in-process adapter for platform plugins.
-// Stable source addresses drive explicit targets; short keys preserve v0.2
-// modules until the executable plugin protocol replaces this registry.
+// providerFactories contains only the v0.2 compatibility implementations.
+// Targets with explicit plugin selectors always execute the declared binary.
 var providerFactories = map[string]func(*schema.Target) (provider.Provider, error){
-	"claude_agents":    claude.Factory,
-	claudePluginSource: claude.Factory,
-	"memory":           memory.Factory,
-	memoryPluginSource: memory.Factory,
+	"claude_agents": claude.Factory,
+	"memory":        memory.Factory,
 }
 
 // platformJob is one reconcile unit: a platform target with its resolved
@@ -29,14 +29,15 @@ var providerFactories = map[string]func(*schema.Target) (provider.Provider, erro
 type platformJob struct {
 	job      *provider.Job
 	provider provider.Provider
+	close    func() error
 }
 
 // preparePlatform runs the shared front half of plan/apply/destroy:
 // validate the module, select the platform targets, resolve their
 // providers, take the state lock, and load the state file. The returned
 // release function must be called (once) when the command is done.
-func preparePlatform(stderr io.Writer, dir, targetName string) (jobs []*platformJob, release func() error, err error) {
-	mod, g, err := compileModule(stderr, dir)
+func preparePlatform(ctx context.Context, stderr io.Writer, dir, targetName string) (jobs []*platformJob, release func() error, err error) {
+	mod, g, err := compileModule(ctx, stderr, dir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -48,27 +49,30 @@ func preparePlatform(stderr io.Writer, dir, targetName string) (jobs []*platform
 	// Resolve providers before locking: a missing provider needs no lock.
 	var resolved []*platformJob
 	for _, tgt := range targets {
-		p, err := providerFor(mod, tgt)
+		p, closeProvider, err := providerFor(ctx, mod, tgt)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Join(err, closePlatformJobs(resolved))
 		}
 		resolved = append(resolved, &platformJob{
 			job:      &provider.Job{Module: mod, Graph: g, Target: tgt},
 			provider: p,
+			close:    closeProvider,
 		})
 	}
 
-	release, err = state.Lock(dir)
+	releaseState, err := state.Lock(dir)
 	if err != nil {
-		return nil, nil, withExitCode(2, err)
+		return nil, nil, withExitCode(2, errors.Join(err, closePlatformJobs(resolved)))
 	}
 	st, err := state.Load(dir)
 	if err != nil {
-		release()
-		return nil, nil, err
+		return nil, nil, errors.Join(err, closePlatformJobs(resolved), releaseState())
 	}
 	for _, pj := range resolved {
 		pj.job.State = st
+	}
+	release = func() error {
+		return errors.Join(closePlatformJobs(resolved), releaseState())
 	}
 	return resolved, release, nil
 }
@@ -114,21 +118,43 @@ func platformNames(mod *module.Module) []string {
 	return names
 }
 
-// providerFor resolves a platform target's plugin through its declared source.
-func providerFor(mod *module.Module, tgt *schema.Target) (provider.Provider, error) {
+// providerFor resolves a platform target through either the explicit
+// executable protocol or the v0.2 in-process compatibility registry.
+func providerFor(ctx context.Context, mod *module.Module, tgt *schema.Target) (provider.Provider, func() error, error) {
+	if tgt.Plugin != "" {
+		client, err := openTargetPlugin(ctx, mod, tgt)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &pluginruntime.Platform{Client: client, Target: tgt}, client.Close, nil
+	}
+
 	source, err := targetPluginSource(mod, tgt)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	factory, ok := providerFactories[source]
 	if !ok {
-		return nil, fmt.Errorf("%s: no platform provider installed for plugin %q (available: %s)", tgt.Addr(), source, joinOrNone(providerNames()))
+		return nil, nil, fmt.Errorf("%s: no platform provider installed for legacy target %q (available: %s)", tgt.Addr(), source, joinOrNone(providerNames()))
 	}
 	p, err := factory(tgt)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", tgt.Addr(), err)
+		return nil, nil, fmt.Errorf("%s: %w", tgt.Addr(), err)
 	}
-	return p, nil
+	return p, nil, nil
+}
+
+func closePlatformJobs(jobs []*platformJob) error {
+	var errs []error
+	for i := len(jobs) - 1; i >= 0; i-- {
+		if jobs[i].close == nil {
+			continue
+		}
+		if err := jobs[i].close(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: close plugin: %w", jobs[i].job.Target.Addr(), err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func providerNames() []string {

--- a/cmd/kastor/platform_test.go
+++ b/cmd/kastor/platform_test.go
@@ -1,19 +1,21 @@
 package main
 
 import (
+	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/weirdGuy/kastor/internal/module"
 	"github.com/weirdGuy/kastor/internal/schema"
 )
 
-func TestClaudeAgentsProviderRegistered(t *testing.T) {
+func TestLegacyClaudeAgentsProviderRegistered(t *testing.T) {
 	const env = "KASTOR_TEST_CLAUDE_REGISTRY_KEY"
 	t.Setenv(env, "test-key")
-	factory, exists := providerFactories[claudePluginSource]
+	factory, exists := providerFactories["claude_agents"]
 	if !exists {
-		t.Fatalf("providerFactories does not contain %s", claudePluginSource)
+		t.Fatal("providerFactories does not contain claude_agents")
 	}
 	got, err := factory(&schema.Target{
 		Name:   "claude_agents",
@@ -25,7 +27,7 @@ func TestClaudeAgentsProviderRegistered(t *testing.T) {
 	}
 }
 
-func TestExplicitMemoryPluginRegistered(t *testing.T) {
+func TestBuiltinMemoryProviderRegistered(t *testing.T) {
 	mod, err := module.Load(filepath.Join("..", "..", "examples", "weather"))
 	if err != nil {
 		t.Fatalf("module.Load: %v", err)
@@ -40,8 +42,51 @@ func TestExplicitMemoryPluginRegistered(t *testing.T) {
 	if target == nil {
 		t.Fatal("weather example does not declare target.memory")
 	}
-	got, err := providerFor(mod, target)
+	if target.Plugin != "" {
+		t.Fatalf("target.memory plugin = %q, want built-in target with no selector", target.Plugin)
+	}
+	got, closeProvider, err := providerFor(context.Background(), mod, target)
 	if err != nil || got == nil {
 		t.Fatalf("providerFor(target.memory) = %v, %v; want provider, nil", got, err)
+	}
+	if closeProvider != nil {
+		t.Fatal("built-in memory provider unexpectedly owns an external process")
+	}
+}
+
+func TestExplicitPlatformTargetUsesProtocolClient(t *testing.T) {
+	client := newFakePluginClient(claudePluginSource, "platform")
+	useFakePlugins(t, client)
+	mod, err := module.Load(filepath.Join("testdata", "external_anthropic"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := mod.Targets[0]
+	got, closeProvider, err := providerFor(context.Background(), mod, target)
+	if err != nil || got == nil || closeProvider == nil {
+		t.Fatalf("providerFor(explicit target) = %T, close=%v, err=%v", got, closeProvider != nil, err)
+	}
+	if err := closeProvider(); err != nil {
+		t.Fatal(err)
+	}
+	if client.closeCalls != 1 {
+		t.Fatalf("close calls = %d, want 1", client.closeCalls)
+	}
+}
+
+func TestExplicitPlatformPlanUsesProtocolClient(t *testing.T) {
+	client := newFakePluginClient(claudePluginSource, "platform")
+	useFakePlugins(t, client)
+	dir := copyModule(t, filepath.Join("testdata", "external_anthropic"))
+	out, err := runCLI(t, "plan", dir)
+	if err != nil {
+		t.Fatalf("plan: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "+ agent.probe (not in state)") {
+		t.Fatalf("plan did not include external resource:\n%s", out)
+	}
+	if client.validateCalls != 1 || client.diffCalls != 1 || client.closeCalls != 2 {
+		t.Fatalf("protocol calls: validate=%d diff=%d close=%d; want 1, 1, 2",
+			client.validateCalls, client.diffCalls, client.closeCalls)
 	}
 }

--- a/cmd/kastor/platform_test.go
+++ b/cmd/kastor/platform_test.go
@@ -1,24 +1,47 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/weirdGuy/kastor/internal/module"
 	"github.com/weirdGuy/kastor/internal/schema"
 )
 
 func TestClaudeAgentsProviderRegistered(t *testing.T) {
 	const env = "KASTOR_TEST_CLAUDE_REGISTRY_KEY"
 	t.Setenv(env, "test-key")
-	factory, exists := providerFactories["claude_agents"]
+	factory, exists := providerFactories[claudePluginSource]
 	if !exists {
-		t.Fatal("providerFactories does not contain claude_agents")
+		t.Fatalf("providerFactories does not contain %s", claudePluginSource)
 	}
 	got, err := factory(&schema.Target{
-		Name: "claude_agents",
-		Type: "platform",
-		Auth: &schema.Auth{APIKeyEnv: env},
+		Name:   "claude_agents",
+		Type:   "platform",
+		Config: map[string]any{"api_key_env": env},
 	})
 	if err != nil || got == nil {
 		t.Fatalf("claude_agents factory = %v, %v; want provider, nil", got, err)
+	}
+}
+
+func TestExplicitMemoryPluginRegistered(t *testing.T) {
+	mod, err := module.Load(filepath.Join("..", "..", "examples", "weather"))
+	if err != nil {
+		t.Fatalf("module.Load: %v", err)
+	}
+	var target *schema.Target
+	for _, candidate := range mod.Targets {
+		if candidate.Name == "memory" {
+			target = candidate
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("weather example does not declare target.memory")
+	}
+	got, err := providerFor(mod, target)
+	if err != nil || got == nil {
+		t.Fatalf("providerFor(target.memory) = %v, %v; want provider, nil", got, err)
 	}
 }

--- a/cmd/kastor/plugins.go
+++ b/cmd/kastor/plugins.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/weirdGuy/kastor/internal/module"
+	"github.com/weirdGuy/kastor/internal/schema"
+)
+
+// Official source addresses are the stable identities stored in
+// required_plugins and, later, the lock file. The short names remain only as
+// v0.2 compatibility aliases while modules migrate to explicit selectors.
+const (
+	langgraphPluginSource = "github.com/getkastor/kastor-langgraph"
+	evePluginSource       = "github.com/getkastor/kastor-eve"
+	claudePluginSource    = "github.com/getkastor/kastor-anthropic"
+	memoryPluginSource    = "github.com/getkastor/kastor-memory"
+)
+
+// targetPluginSource resolves a target instance to an implementation
+// identity. Explicit targets always resolve through required_plugins. An empty
+// selector is the v0.2 compatibility path, where the target label was also the
+// implementation name.
+func targetPluginSource(mod *module.Module, tgt *schema.Target) (string, error) {
+	if tgt.Plugin == "" {
+		return tgt.Name, nil
+	}
+	requirement, ok := mod.PluginRequirement(tgt.Plugin)
+	if !ok {
+		return "", fmt.Errorf("%s: plugin %q is not declared in kastor.required_plugins", tgt.Addr(), tgt.Plugin)
+	}
+	return requirement.Source, nil
+}
+
+type targetCapabilities struct {
+	stdio                 bool
+	envCredentials        bool
+	connectionCredentials bool
+	requiresVault         bool
+	stringConfigKeys      map[string]bool
+}
+
+var builtinCapabilities = map[string]targetCapabilities{
+	"langgraph": {
+		stdio:          true,
+		envCredentials: true,
+	},
+	langgraphPluginSource: {
+		stdio:          true,
+		envCredentials: true,
+	},
+	"eve": {
+		envCredentials: true,
+	},
+	evePluginSource: {
+		envCredentials: true,
+	},
+	"claude_agents": {
+		connectionCredentials: true,
+		requiresVault:         true,
+		stringConfigKeys:      map[string]bool{"api_key_env": true, "vault_id": true},
+	},
+	claudePluginSource: {
+		connectionCredentials: true,
+		requiresVault:         true,
+		stringConfigKeys:      map[string]bool{"api_key_env": true, "vault_id": true},
+	},
+	"memory": {
+		envCredentials: true,
+	},
+	memoryPluginSource: {
+		envCredentials: true,
+	},
+}
+
+// validateTargetPlugins is the temporary in-process implementation adapter.
+// Core parsing and module resolution know only opaque config and plugin
+// identities; target-specific transport and credential rules live here until
+// the protocol-v1 capability RPC replaces this table (KAS-77).
+func validateTargetPlugins(mod *module.Module) error {
+	referenced := referencedMCPServers(mod)
+	var errs []error
+	for _, tgt := range mod.Targets {
+		source, err := targetPluginSource(mod, tgt)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		caps, known := builtinCapabilities[source]
+		if !known {
+			continue
+		}
+		configKeys := make([]string, 0, len(tgt.Config))
+		for key := range tgt.Config {
+			configKeys = append(configKeys, key)
+		}
+		sort.Strings(configKeys)
+		for _, key := range configKeys {
+			if !caps.stringConfigKeys[key] {
+				errs = append(errs, fmt.Errorf("%s: plugin %q does not support config attribute %q", tgt.Addr(), source, key))
+				continue
+			}
+			if _, ok := tgt.Config[key].(string); !ok {
+				errs = append(errs, fmt.Errorf("%s: plugin %q config attribute %q must be a string", tgt.Addr(), source, key))
+			}
+		}
+		for _, server := range mod.MCPServers {
+			if !referenced[server.Name] {
+				continue
+			}
+			if server.Transport == "stdio" && !caps.stdio {
+				errs = append(errs, fmt.Errorf("%s: transport \"stdio\" cannot be bound on %s; plugin %q does not advertise local-process support",
+					server.Addr(), tgt.Addr(), source))
+			}
+			auth, ok := server.AuthFor(tgt.Addr())
+			if !ok {
+				continue
+			}
+			scheme, _, err := schema.ParseCredentialRef(auth.Ref)
+			if err != nil {
+				continue
+			}
+			switch scheme {
+			case schema.SchemeEnv:
+				if !caps.envCredentials {
+					errs = append(errs, fmt.Errorf("%s: auth ref %q cannot be bound on %s; plugin %q does not support env:// credentials",
+						server.Addr(), auth.Ref, tgt.Addr(), source))
+				}
+			case schema.SchemeConnection:
+				if !caps.connectionCredentials {
+					errs = append(errs, fmt.Errorf("%s: auth ref %q cannot be bound on %s; plugin %q does not support connection:// credentials",
+						server.Addr(), auth.Ref, tgt.Addr(), source))
+					continue
+				}
+				if caps.requiresVault {
+					vault, ok := tgt.ConfigString("vault_id")
+					if !ok || vault == "" {
+						errs = append(errs, fmt.Errorf("%s: auth ref %q needs a vault to resolve against; %s plugin config must declare \"vault_id\"",
+							server.Addr(), auth.Ref, tgt.Addr()))
+					}
+				}
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func referencedMCPServers(mod *module.Module) map[string]bool {
+	referenced := map[string]bool{}
+	for _, tool := range mod.Tools {
+		if tool.Source == nil || tool.Source.Kind != "mcp" {
+			continue
+		}
+		server, _, err := schema.ParseMCPURI(tool.Source.URI)
+		if err == nil {
+			referenced[server] = true
+		}
+	}
+	return referenced
+}

--- a/cmd/kastor/plugins.go
+++ b/cmd/kastor/plugins.go
@@ -13,10 +13,10 @@ import (
 // required_plugins and, later, the lock file. The short names remain only as
 // v0.2 compatibility aliases while modules migrate to explicit selectors.
 const (
-	langgraphPluginSource = "github.com/getkastor/kastor-langgraph"
-	evePluginSource       = "github.com/getkastor/kastor-eve"
-	claudePluginSource    = "github.com/getkastor/kastor-anthropic"
-	memoryPluginSource    = "github.com/getkastor/kastor-memory"
+	langgraphPluginSource = "github.com/getkastordev/kastor-langgraph"
+	evePluginSource       = "github.com/getkastordev/kastor-eve"
+	claudePluginSource    = "github.com/getkastordev/kastor-anthropic"
+	memoryPluginSource    = "github.com/getkastordev/kastor-memory"
 )
 
 // targetPluginSource resolves a target instance to an implementation

--- a/cmd/kastor/plugins.go
+++ b/cmd/kastor/plugins.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/weirdGuy/kastor/internal/module"
+	pluginruntime "github.com/weirdGuy/kastor/internal/plugin"
 	"github.com/weirdGuy/kastor/internal/schema"
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
 )
 
 // Official source addresses are the stable identities stored in
@@ -16,8 +20,11 @@ const (
 	langgraphPluginSource = "github.com/getkastordev/kastor-langgraph"
 	evePluginSource       = "github.com/getkastordev/kastor-eve"
 	claudePluginSource    = "github.com/getkastordev/kastor-anthropic"
-	memoryPluginSource    = "github.com/getkastordev/kastor-memory"
 )
+
+// openPlugin is a narrow test seam around executable discovery and startup.
+// Production always uses pluginruntime.Open.
+var openPlugin = pluginruntime.Open
 
 // targetPluginSource resolves a target instance to an implementation
 // identity. Explicit targets always resolve through required_plugins. An empty
@@ -47,14 +54,7 @@ var builtinCapabilities = map[string]targetCapabilities{
 		stdio:          true,
 		envCredentials: true,
 	},
-	langgraphPluginSource: {
-		stdio:          true,
-		envCredentials: true,
-	},
 	"eve": {
-		envCredentials: true,
-	},
-	evePluginSource: {
 		envCredentials: true,
 	},
 	"claude_agents": {
@@ -62,27 +62,56 @@ var builtinCapabilities = map[string]targetCapabilities{
 		requiresVault:         true,
 		stringConfigKeys:      map[string]bool{"api_key_env": true, "vault_id": true},
 	},
-	claudePluginSource: {
-		connectionCredentials: true,
-		requiresVault:         true,
-		stringConfigKeys:      map[string]bool{"api_key_env": true, "vault_id": true},
-	},
 	"memory": {
-		envCredentials: true,
-	},
-	memoryPluginSource: {
 		envCredentials: true,
 	},
 }
 
-// validateTargetPlugins is the temporary in-process implementation adapter.
-// Core parsing and module resolution know only opaque config and plugin
-// identities; target-specific transport and credential rules live here until
-// the protocol-v1 capability RPC replaces this table (KAS-77).
-func validateTargetPlugins(mod *module.Module) error {
+// validateTargetPlugins delegates explicit selectors to the executable that
+// owns them. The static table is retained only for v0.2 targets with no
+// plugin selector, so old modules keep working during the migration window.
+func validateTargetPlugins(ctx context.Context, warnings io.Writer, mod *module.Module) error {
 	referenced := referencedMCPServers(mod)
 	var errs []error
+	clients := map[string]pluginruntime.Client{}
+
 	for _, tgt := range mod.Targets {
+		if tgt.Plugin != "" {
+			client := clients[tgt.Plugin]
+			if client == nil {
+				var err error
+				client, err = openTargetPlugin(ctx, mod, tgt)
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				clients[tgt.Plugin] = client
+			} else if err := requireTargetKind(tgt, client.Metadata()); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			response, err := client.Validate(ctx, &protocol.ValidateRequest{
+				Module: pluginruntime.ModuleIR(mod, nil),
+				Target: pluginruntime.TargetIR(tgt),
+			})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s: plugin validation failed: %w", tgt.Addr(), err))
+				continue
+			}
+			if response == nil {
+				errs = append(errs, fmt.Errorf("%s: plugin validation returned no response", tgt.Addr()))
+				continue
+			}
+			for _, diagnostic := range response.Diagnostics {
+				if diagnostic.Severity == protocol.SeverityWarning {
+					fmt.Fprintf(warnings, "Warning: %s\n", diagnosticError(diagnostic))
+					continue
+				}
+				errs = append(errs, diagnosticError(diagnostic))
+			}
+			continue
+		}
+
 		source, err := targetPluginSource(mod, tgt)
 		if err != nil {
 			errs = append(errs, err)
@@ -144,7 +173,53 @@ func validateTargetPlugins(mod *module.Module) error {
 			}
 		}
 	}
+	localNames := make([]string, 0, len(clients))
+	for localName := range clients {
+		localNames = append(localNames, localName)
+	}
+	sort.Strings(localNames)
+	for _, localName := range localNames {
+		client := clients[localName]
+		if err := client.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("plugin.%s: close: %w", localName, err))
+		}
+	}
 	return errors.Join(errs...)
+}
+
+func openTargetPlugin(ctx context.Context, mod *module.Module, tgt *schema.Target) (pluginruntime.Client, error) {
+	requirement, ok := mod.PluginRequirement(tgt.Plugin)
+	if !ok {
+		return nil, fmt.Errorf("%s: plugin %q is not declared in kastor.required_plugins", tgt.Addr(), tgt.Plugin)
+	}
+	client, err := openPlugin(ctx, tgt.Plugin, requirement)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", tgt.Addr(), err)
+	}
+	if err := requireTargetKind(tgt, client.Metadata()); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+	return client, nil
+}
+
+func requireTargetKind(tgt *schema.Target, metadata protocol.Metadata) error {
+	kind := protocol.Kind(tgt.Type)
+	if metadata.Supports(kind) {
+		return nil
+	}
+	return fmt.Errorf("%s: plugin %q does not advertise %s support", tgt.Addr(), metadata.Source, kind)
+}
+
+func diagnosticError(diagnostic protocol.Diagnostic) error {
+	message := diagnostic.Summary
+	if diagnostic.Addr != "" {
+		message = diagnostic.Addr + ": " + message
+	}
+	if diagnostic.Detail != "" {
+		message += " (" + diagnostic.Detail + ")"
+	}
+	return errors.New(message)
 }
 
 func referencedMCPServers(mod *module.Module) map[string]bool {

--- a/cmd/kastor/plugins.go
+++ b/cmd/kastor/plugins.go
@@ -121,6 +121,9 @@ func validateTargetPlugins(ctx context.Context, warnings io.Writer, mod *module.
 		if !known {
 			continue
 		}
+		if source != "memory" {
+			fmt.Fprintf(warnings, "Warning: %s uses legacy target-name implementation selection; declare it in kastor.required_plugins and set plugin on the target\n", tgt.Addr())
+		}
 		configKeys := make([]string, 0, len(tgt.Config))
 		for key := range tgt.Config {
 			configKeys = append(configKeys, key)

--- a/cmd/kastor/plugins_test.go
+++ b/cmd/kastor/plugins_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"path/filepath"
@@ -74,5 +75,21 @@ func TestTargetPluginSourceUsesRequirementNotTargetLabel(t *testing.T) {
 	}
 	if got != evePluginSource {
 		t.Errorf("targetPluginSource = %q, want %q", got, evePluginSource)
+	}
+}
+
+func TestLegacyTargetReportsMigrationWarning(t *testing.T) {
+	mod, err := module.Load(filepath.Join("testdata", "build", "single"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var warnings bytes.Buffer
+	if err := validateTargetPlugins(context.Background(), &warnings, mod); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"target.langgraph", "kastor.required_plugins", "set plugin"} {
+		if !strings.Contains(warnings.String(), want) {
+			t.Errorf("warning missing %q:\n%s", want, warnings.String())
+		}
 	}
 }

--- a/cmd/kastor/plugins_test.go
+++ b/cmd/kastor/plugins_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,32 +18,35 @@ func TestExplicitPluginCapabilityValidation(t *testing.T) {
 		{
 			dir: "bad_credential_targets",
 			wantErrs: []string{
-				`mcp_server.hubspot: auth ref "connection://cred_011CZkZDLs7fYzm1hXNPeRjv" needs a vault to resolve against; target.prod plugin config must declare "vault_id"`,
-				`mcp_server.airtable: auth ref "env://AIRTABLE_TOKEN" cannot be bound on target.prod; plugin "github.com/getkastordev/kastor-anthropic" does not support env:// credentials`,
+				`target.prod: vault_id is required for connection credentials (connection://cred_011CZkZDLs7fYzm1hXNPeRjv)`,
+				`mcp_server.airtable: unsupported credential scheme (env://)`,
 			},
 		},
 		{
 			dir: "stdio_on_platform",
 			wantErrs: []string{
-				`mcp_server.fetch: transport "stdio" cannot be bound on target.prod; plugin "github.com/getkastordev/kastor-anthropic" does not advertise local-process support`,
+				`mcp_server.fetch: stdio transport is not supported (Claude Managed Agents requires an HTTP endpoint)`,
 			},
 		},
 		{
 			dir: "stdio_on_eve",
 			wantErrs: []string{
-				`mcp_server.fetch: transport "stdio" cannot be bound on target.typescript; plugin "github.com/getkastordev/kastor-eve" does not advertise local-process support`,
+				`mcp_server.fetch: stdio transport is not supported (Eve connections require an HTTP endpoint)`,
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.dir, func(t *testing.T) {
+			anthropic := newFakePluginClient(claudePluginSource, "platform")
+			eve := newFakePluginClient(evePluginSource, "codegen")
+			useFakePlugins(t, anthropic, eve)
 			root := filepath.Join("..", "..", "internal", "module", "testdata", tc.dir)
 			mod, err := module.Load(root)
 			if err != nil {
 				t.Fatalf("module.Load: %v", err)
 			}
-			err = validateTargetPlugins(mod)
+			err = validateTargetPlugins(context.Background(), io.Discard, mod)
 			if err == nil {
 				t.Fatalf("validateTargetPlugins: expected %q, got nil", tc.wantErrs)
 			}
@@ -49,6 +54,9 @@ func TestExplicitPluginCapabilityValidation(t *testing.T) {
 				if !strings.Contains(err.Error(), want) {
 					t.Errorf("validateTargetPlugins error = %q\nwant substring %q", err, want)
 				}
+			}
+			if anthropic.validateCalls+eve.validateCalls != 1 {
+				t.Errorf("external validate calls = %d, want 1", anthropic.validateCalls+eve.validateCalls)
 			}
 		})
 	}

--- a/cmd/kastor/plugins_test.go
+++ b/cmd/kastor/plugins_test.go
@@ -17,19 +17,19 @@ func TestExplicitPluginCapabilityValidation(t *testing.T) {
 			dir: "bad_credential_targets",
 			wantErrs: []string{
 				`mcp_server.hubspot: auth ref "connection://cred_011CZkZDLs7fYzm1hXNPeRjv" needs a vault to resolve against; target.prod plugin config must declare "vault_id"`,
-				`mcp_server.airtable: auth ref "env://AIRTABLE_TOKEN" cannot be bound on target.prod; plugin "github.com/getkastor/kastor-anthropic" does not support env:// credentials`,
+				`mcp_server.airtable: auth ref "env://AIRTABLE_TOKEN" cannot be bound on target.prod; plugin "github.com/getkastordev/kastor-anthropic" does not support env:// credentials`,
 			},
 		},
 		{
 			dir: "stdio_on_platform",
 			wantErrs: []string{
-				`mcp_server.fetch: transport "stdio" cannot be bound on target.prod; plugin "github.com/getkastor/kastor-anthropic" does not advertise local-process support`,
+				`mcp_server.fetch: transport "stdio" cannot be bound on target.prod; plugin "github.com/getkastordev/kastor-anthropic" does not advertise local-process support`,
 			},
 		},
 		{
 			dir: "stdio_on_eve",
 			wantErrs: []string{
-				`mcp_server.fetch: transport "stdio" cannot be bound on target.typescript; plugin "github.com/getkastor/kastor-eve" does not advertise local-process support`,
+				`mcp_server.fetch: transport "stdio" cannot be bound on target.typescript; plugin "github.com/getkastordev/kastor-eve" does not advertise local-process support`,
 			},
 		},
 	}

--- a/cmd/kastor/plugins_test.go
+++ b/cmd/kastor/plugins_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/weirdGuy/kastor/internal/module"
+)
+
+func TestExplicitPluginCapabilityValidation(t *testing.T) {
+	tests := []struct {
+		dir      string
+		wantErrs []string
+	}{
+		{
+			dir: "bad_credential_targets",
+			wantErrs: []string{
+				`mcp_server.hubspot: auth ref "connection://cred_011CZkZDLs7fYzm1hXNPeRjv" needs a vault to resolve against; target.prod plugin config must declare "vault_id"`,
+				`mcp_server.airtable: auth ref "env://AIRTABLE_TOKEN" cannot be bound on target.prod; plugin "github.com/getkastor/kastor-anthropic" does not support env:// credentials`,
+			},
+		},
+		{
+			dir: "stdio_on_platform",
+			wantErrs: []string{
+				`mcp_server.fetch: transport "stdio" cannot be bound on target.prod; plugin "github.com/getkastor/kastor-anthropic" does not advertise local-process support`,
+			},
+		},
+		{
+			dir: "stdio_on_eve",
+			wantErrs: []string{
+				`mcp_server.fetch: transport "stdio" cannot be bound on target.typescript; plugin "github.com/getkastor/kastor-eve" does not advertise local-process support`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.dir, func(t *testing.T) {
+			root := filepath.Join("..", "..", "internal", "module", "testdata", tc.dir)
+			mod, err := module.Load(root)
+			if err != nil {
+				t.Fatalf("module.Load: %v", err)
+			}
+			err = validateTargetPlugins(mod)
+			if err == nil {
+				t.Fatalf("validateTargetPlugins: expected %q, got nil", tc.wantErrs)
+			}
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("validateTargetPlugins error = %q\nwant substring %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestTargetPluginSourceUsesRequirementNotTargetLabel(t *testing.T) {
+	root := filepath.Join("..", "..", "internal", "module", "testdata", "stdio_on_eve")
+	mod, err := module.Load(root)
+	if err != nil {
+		t.Fatalf("module.Load: %v", err)
+	}
+	got, err := targetPluginSource(mod, mod.Targets[0])
+	if err != nil {
+		t.Fatalf("targetPluginSource: %v", err)
+	}
+	if got != evePluginSource {
+		t.Errorf("targetPluginSource = %q, want %q", got, evePluginSource)
+	}
+}

--- a/cmd/kastor/scaffold/langgraph/kastor.hcl
+++ b/cmd/kastor/scaffold/langgraph/kastor.hcl
@@ -1,7 +1,7 @@
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
   }

--- a/cmd/kastor/scaffold/langgraph/kastor.hcl
+++ b/cmd/kastor/scaffold/langgraph/kastor.hcl
@@ -1,3 +1,12 @@
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
@@ -11,6 +20,7 @@ model "fast" {
 # Codegen target -> `kastor build` emits a runnable LangGraph project
 target "langgraph" {
   type   = "codegen"
+  plugin = "langgraph"
   output = "./gen/langgraph"
 }
 

--- a/cmd/kastor/testdata/build/platform_only/kastor.hcl
+++ b/cmd/kastor/testdata/build/platform_only/kastor.hcl
@@ -1,7 +1,7 @@
 target "openai_assistants" {
   type = "platform"
 
-  auth {
+  config {
     api_key_env = "OPENAI_API_KEY"
   }
 }

--- a/cmd/kastor/testdata/build/requires_approval/kastor.hcl
+++ b/cmd/kastor/testdata/build/requires_approval/kastor.hcl
@@ -16,7 +16,7 @@ target "langgraph" {
 target "claude_agents" {
   type = "platform"
 
-  auth {
+  config {
     api_key_env = "ANTHROPIC_API_KEY"
   }
 }

--- a/cmd/kastor/testdata/claude_acceptance/kastor.hcl
+++ b/cmd/kastor/testdata/claude_acceptance/kastor.hcl
@@ -6,7 +6,7 @@ model "acceptance" {
 target "claude_agents" {
   type = "platform"
 
-  auth {
+  config {
     api_key_env = "ANTHROPIC_API_KEY"
   }
 }

--- a/cmd/kastor/testdata/claude_plan/kastor.hcl
+++ b/cmd/kastor/testdata/claude_plan/kastor.hcl
@@ -6,7 +6,7 @@ model "haiku" {
 target "claude_agents" {
   type = "platform"
 
-  auth {
+  config {
     api_key_env = "ANTHROPIC_API_KEY"
   }
 }

--- a/cmd/kastor/testdata/doctor/kastor.hcl
+++ b/cmd/kastor/testdata/doctor/kastor.hcl
@@ -4,11 +4,11 @@ model "fast" {
 }
 
 target "claude_agents" {
-  type     = "platform"
-  vault_id = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
+  type = "platform"
 
-  auth {
+  config {
     api_key_env = "KASTOR_DOCTOR_CLI_KEY"
+    vault_id    = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
   }
 }
 

--- a/cmd/kastor/testdata/external_anthropic/kastor.hcl
+++ b/cmd/kastor/testdata/external_anthropic/kastor.hcl
@@ -1,0 +1,22 @@
+kastor {
+  required_plugins {
+    anthropic = {
+      source  = "github.com/getkastordev/kastor-anthropic"
+      version = "~> 0.1"
+    }
+  }
+}
+
+model "fast" {
+  provider = "anthropic"
+  id       = "claude-haiku-4-5"
+}
+
+target "prod" {
+  type   = "platform"
+  plugin = "anthropic"
+
+  config {
+    api_key_env = "ANTHROPIC_API_KEY"
+  }
+}

--- a/cmd/kastor/testdata/external_anthropic/probe.agent
+++ b/cmd/kastor/testdata/external_anthropic/probe.agent
@@ -1,0 +1,4 @@
+agent "probe" {
+  description = "Exercises the external platform diff contract"
+  model       = model.fast
+}

--- a/cmd/kastor/testdata/mcp_credentials/kastor.hcl
+++ b/cmd/kastor/testdata/mcp_credentials/kastor.hcl
@@ -11,8 +11,11 @@ target "fake" {
 }
 
 target "claude_agents" {
-  type     = "platform"
-  vault_id = "vlt_011CZkZDLs7fYzm1hXNPeRjvVAULT"
+  type = "platform"
+
+  config {
+    vault_id = "vlt_011CZkZDLs7fYzm1hXNPeRjvVAULT"
+  }
 }
 
 mcp_server "hubspot" {

--- a/cmd/kastor/testdata/platform_memory_auth/kastor.hcl
+++ b/cmd/kastor/testdata/platform_memory_auth/kastor.hcl
@@ -3,12 +3,12 @@ model "fast" {
   id       = "gpt-4o-mini"
 }
 
-# Invalid: auth is meaningless on the in-memory platform and must be an
+# Invalid: config is meaningless on the in-memory platform and must be an
 # error, not ignored.
 target "memory" {
   type = "platform"
 
-  auth {
+  config {
     api_key_env = "NOPE"
   }
 }

--- a/cmd/kastor/validate.go
+++ b/cmd/kastor/validate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -24,13 +25,13 @@ func newValidateCmd() *cobra.Command {
 			if len(args) == 1 {
 				dir = args[0]
 			}
-			return runValidate(cmd.OutOrStdout(), cmd.ErrOrStderr(), dir)
+			return runValidate(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), dir)
 		},
 	}
 }
 
-func runValidate(stdout, stderr io.Writer, dir string) error {
-	mod, _, err := compileModule(stderr, dir)
+func runValidate(ctx context.Context, stdout, stderr io.Writer, dir string) error {
+	mod, _, err := compileModule(ctx, stderr, dir)
 	if err != nil {
 		return err
 	}
@@ -44,11 +45,11 @@ func runValidate(stdout, stderr io.Writer, dir string) error {
 // run because the next stage needs its output; diagnostics within a stage
 // are always reported in full to stderr. Both validate and build sit on this
 // — build must never generate from a module that fails it.
-func compileModule(stderr io.Writer, dir string) (*module.Module, *graph.Graph, error) {
+func compileModule(ctx context.Context, stderr io.Writer, dir string) (*module.Module, *graph.Graph, error) {
 	mod, err := module.Load(dir)
 	var g *graph.Graph
 	if err == nil {
-		err = validateTargetPlugins(mod)
+		err = validateTargetPlugins(ctx, stderr, mod)
 	}
 	if err == nil {
 		g, err = graph.Build(mod)

--- a/cmd/kastor/validate.go
+++ b/cmd/kastor/validate.go
@@ -48,6 +48,9 @@ func compileModule(stderr io.Writer, dir string) (*module.Module, *graph.Graph, 
 	mod, err := module.Load(dir)
 	var g *graph.Graph
 	if err == nil {
+		err = validateTargetPlugins(mod)
+	}
+	if err == nil {
 		g, err = graph.Build(mod)
 	}
 	if err != nil {
@@ -106,6 +109,7 @@ func moduleSummary(mod *module.Module) string {
 		countNoun(len(mod.Agents), "agent"),
 		countNoun(len(mod.Tools), "tool"),
 		countNoun(len(mod.Prompts), "prompt"),
+		countNoun(len(mod.Plugins), "plugin"),
 		countNoun(len(mod.Models), "model"),
 		countNoun(len(mod.Targets), "target"),
 	}, ", ")

--- a/examples/scheduler/kastor.hcl
+++ b/examples/scheduler/kastor.hcl
@@ -1,7 +1,7 @@
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
   }

--- a/examples/scheduler/kastor.hcl
+++ b/examples/scheduler/kastor.hcl
@@ -1,3 +1,12 @@
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
@@ -8,5 +17,6 @@ model "fast" {
 
 target "langgraph" {
   type   = "codegen"
+  plugin = "langgraph"
   output = "./gen/langgraph"
 }

--- a/examples/support-triage/kastor.hcl
+++ b/examples/support-triage/kastor.hcl
@@ -1,11 +1,11 @@
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
     eve = {
-      source  = "github.com/getkastor/kastor-eve"
+      source  = "github.com/getkastordev/kastor-eve"
       version = "~> 0.1"
     }
   }

--- a/examples/support-triage/kastor.hcl
+++ b/examples/support-triage/kastor.hcl
@@ -1,3 +1,16 @@
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+    eve = {
+      source  = "github.com/getkastor/kastor-eve"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
@@ -11,11 +24,13 @@ model "fast" {
 # Codegen target -> `kastor build` emits a runnable LangGraph project
 target "langgraph" {
   type   = "codegen"
+  plugin = "langgraph"
   output = "./gen/langgraph"
 }
 
 # Codegen target -> `kastor build` emits one eve project per root agent
 target "eve" {
   type   = "codegen"
+  plugin = "eve"
   output = "./gen/eve"
 }

--- a/examples/weather/kastor.hcl
+++ b/examples/weather/kastor.hcl
@@ -8,10 +8,6 @@ kastor {
       source  = "github.com/getkastordev/kastor-eve"
       version = "~> 0.1"
     }
-    memory = {
-      source  = "github.com/getkastordev/kastor-memory"
-      version = "~> 0.1"
-    }
   }
 }
 
@@ -44,8 +40,7 @@ target "eve" {
 # `target "claude_agents"` once the Claude Managed Agents provider ships
 # (SPEC.md section 8).
 target "memory" {
-  type   = "platform"
-  plugin = "memory"
+  type = "platform"
 }
 
 # The MCP server tool.web_search binds to. Declaring it is what makes

--- a/examples/weather/kastor.hcl
+++ b/examples/weather/kastor.hcl
@@ -1,15 +1,15 @@
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
     eve = {
-      source  = "github.com/getkastor/kastor-eve"
+      source  = "github.com/getkastordev/kastor-eve"
       version = "~> 0.1"
     }
     memory = {
-      source  = "github.com/getkastor/kastor-memory"
+      source  = "github.com/getkastordev/kastor-memory"
       version = "~> 0.1"
     }
   }

--- a/examples/weather/kastor.hcl
+++ b/examples/weather/kastor.hcl
@@ -1,3 +1,20 @@
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+    eve = {
+      source  = "github.com/getkastor/kastor-eve"
+      version = "~> 0.1"
+    }
+    memory = {
+      source  = "github.com/getkastor/kastor-memory"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
@@ -11,12 +28,14 @@ model "fast" {
 # Codegen target -> exercises the module-walk skip of target output paths (#6)
 target "langgraph" {
   type   = "codegen"
+  plugin = "langgraph"
   output = "./gen/langgraph"
 }
 
 # Codegen target -> `kastor build` emits one eve project per root agent
 target "eve" {
   type   = "codegen"
+  plugin = "eve"
   output = "./gen/eve"
 }
 
@@ -25,7 +44,8 @@ target "eve" {
 # `target "claude_agents"` once the Claude Managed Agents provider ships
 # (SPEC.md section 8).
 target "memory" {
-  type = "platform"
+  type   = "platform"
+  plugin = "memory"
 }
 
 # The MCP server tool.web_search binds to. Declaring it is what makes

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -27,6 +27,7 @@ type Module struct {
 	Agents     []*schema.Agent
 	Tools      []*schema.Tool
 	Prompts    []*schema.Prompt
+	Plugins    []*schema.PluginRequirement
 	Models     []*schema.Model
 	Targets    []*schema.Target
 	MCPServers []*schema.MCPServer
@@ -37,9 +38,9 @@ type Module struct {
 // Symbol is one addressable block in the module's symbol table.
 type Symbol struct {
 	Addr  string // block address, e.g. "agent.weather"
-	Kind  string // agent | tool | prompt | model | target | mcp_server
+	Kind  string // agent | tool | prompt | plugin | model | target | mcp_server
 	File  string // declaring file, relative to the module root
-	Block any    // *schema.Agent, *schema.Tool, *schema.Prompt, *schema.Model, *schema.Target, or *schema.MCPServer
+	Block any
 }
 
 // Lookup resolves a block address against the module's symbol table.
@@ -75,8 +76,10 @@ func Load(root string) (*Module, error) {
 	for _, s := range mod.MCPServers {
 		errs = append(errs, mod.resolveMCPServer(s)...)
 	}
+	for _, t := range mod.Targets {
+		errs = append(errs, mod.resolveTargetPlugin(t)...)
+	}
 	errs = append(errs, mod.checkAuthCoverage()...)
-	errs = append(errs, mod.checkCredentialTargets()...)
 
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
@@ -232,6 +235,11 @@ func (m *Module) loadFile(path, rel string) []error {
 		if err != nil {
 			return []error{fileErr(rel, err)}
 		}
+		for _, plugin := range project.Plugins {
+			if define("plugin", plugin.Addr(), plugin) {
+				m.Plugins = append(m.Plugins, plugin)
+			}
+		}
 		for _, mdl := range project.Models {
 			if define("model", mdl.Addr(), mdl) {
 				m.Models = append(m.Models, mdl)
@@ -249,6 +257,31 @@ func (m *Module) loadFile(path, rel string) []error {
 		}
 	}
 	return errs
+}
+
+// PluginRequirement resolves a target's explicit local plugin name to its
+// installation coordinates. Legacy v0.2 targets have an empty Plugin and are
+// intentionally absent from this lookup; the CLI compatibility adapter owns
+// their temporary label-based resolution.
+func (m *Module) PluginRequirement(localName string) (*schema.PluginRequirement, bool) {
+	sym, ok := m.symbols["plugin."+localName]
+	if !ok || sym.Kind != "plugin" {
+		return nil, false
+	}
+	plugin, ok := sym.Block.(*schema.PluginRequirement)
+	return plugin, ok
+}
+
+func (m *Module) resolveTargetPlugin(t *schema.Target) []error {
+	if t.Plugin == "" {
+		return nil
+	}
+	if _, ok := m.PluginRequirement(t.Plugin); ok {
+		return nil
+	}
+	file := m.symbols[t.Addr()].File
+	return []error{fmt.Errorf("%s: %s: plugin %q is not declared in kastor.required_plugins (declared plugins: %s)",
+		file, t.Addr(), t.Plugin, joinOrNone(m.pluginNames()))}
 }
 
 // resolveAgent checks every reference captured on an agent against the
@@ -400,94 +433,19 @@ func (m *Module) checkAuthCoverage() []error {
 	return errs
 }
 
-// claudeTargetName is the target label that selects the Claude Managed Agents
-// provider (SPEC.md §3.5). eveTargetName is the codegen target whose MCP
-// binding is an HTTP client, which is what puts it in the transport matrix.
-const (
-	claudeTargetName = "claude_agents"
-	eveTargetName    = "eve"
-)
-
-// checkCredentialTargets enforces the (scheme, target) matrix of SPEC.md §3.6
-// and the transport matrix above it, plus §3.5's rule that a target whose
-// servers use connection:// must declare the vault those credentials live in.
-//
-// The rejected (scheme, target) pairs are exactly the ones that would force
-// kastor to read a secret and transmit it: env:// on a platform target means
-// kastor resolving the variable and sending its value, and connection:// off
-// the platform means there is no platform store to match the id against.
-func (m *Module) checkCredentialTargets() []error {
-	referenced := map[string]bool{}
-	for _, t := range m.Tools {
-		if t.Source == nil || t.Source.Kind != "mcp" {
-			continue
-		}
-		if server, _, err := schema.ParseMCPURI(t.Source.URI); err == nil {
-			referenced[server] = true
-		}
-	}
-
-	var errs []error
-	for _, s := range m.MCPServers {
-		if !referenced[s.Name] {
-			continue // an unreferenced server is bound nowhere
-		}
-		file := m.symbols[s.Addr()].File
-
-		for _, tgt := range m.Targets {
-			// The transport matrix of §3.6: stdio is spawned by a generated
-			// langgraph project, but a platform dials a URL and eve's MCP
-			// binding is an HTTP client, so neither can reach a local process.
-			switch {
-			case s.Transport != "stdio":
-			case tgt.Type == "platform":
-				errs = append(errs, fmt.Errorf("%s: %s: transport \"stdio\" cannot be bound on %s; a platform dials a URL and cannot spawn a local process",
-					file, s.Addr(), tgt.Addr()))
-			case tgt.Name == eveTargetName:
-				errs = append(errs, fmt.Errorf("%s: %s: transport \"stdio\" cannot be bound on %s; the generated connection is an HTTP client — put an HTTP bridge in front of the server and declare its url",
-					file, s.Addr(), tgt.Addr()))
-			}
-
-			auth, ok := s.AuthFor(tgt.Addr())
-			if !ok {
-				continue
-			}
-			scheme, _, err := schema.ParseCredentialRef(auth.Ref)
-			if err != nil {
-				continue // already reported at parse time
-			}
-			switch scheme {
-			case schema.SchemeEnv:
-				// Rejected on claude_agents specifically, per §3.6's table:
-				// the platform's agent object accepts no credential, so
-				// honoring env:// would mean kastor reading the variable and
-				// transmitting its value. Other platform targets are not
-				// listed and are not rejected — target.memory dials nothing,
-				// so a binding on it is unused rather than wrong.
-				if tgt.Name == claudeTargetName {
-					errs = append(errs, fmt.Errorf("%s: %s: auth ref %q cannot be bound on %s; the platform's agent object accepts no credential and kastor never reads a credential value — use connection://<credential_id>",
-						file, s.Addr(), auth.Ref, tgt.Addr()))
-				}
-			case schema.SchemeConnection:
-				if tgt.Name != claudeTargetName {
-					errs = append(errs, fmt.Errorf("%s: %s: auth ref %q cannot be bound on %s; only %s holds platform connections — use env://<NAME>",
-						file, s.Addr(), auth.Ref, tgt.Addr(), "target."+claudeTargetName))
-					continue
-				}
-				if tgt.VaultID == "" {
-					errs = append(errs, fmt.Errorf("%s: %s: auth ref %q needs a vault to resolve against; %s must declare \"vault_id\"",
-						file, s.Addr(), auth.Ref, tgt.Addr()))
-				}
-			}
-		}
-	}
-	return errs
-}
-
 func (m *Module) mcpServerNames() []string {
 	names := make([]string, 0, len(m.MCPServers))
 	for _, s := range m.MCPServers {
 		names = append(names, s.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (m *Module) pluginNames() []string {
+	names := make([]string, 0, len(m.Plugins))
+	for _, p := range m.Plugins {
+		names = append(names, p.Name)
 	}
 	sort.Strings(names)
 	return names

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -222,32 +222,17 @@ func TestLoadErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "credential schemes are checked against the target they bind on",
-			dir:  "bad_credential_targets",
-			wantErrs: []string{
-				`mcp_server.hubspot: auth ref "connection://cred_011CZkZDLs7fYzm1hXNPeRjv" needs a vault to resolve against; target.claude_agents must declare "vault_id"`,
-				`mcp_server.airtable: auth ref "env://AIRTABLE_TOKEN" cannot be bound on target.claude_agents`,
-			},
-		},
-		{
-			name: "a stdio server cannot be bound on a platform target",
-			dir:  "stdio_on_platform",
-			wantErrs: []string{
-				`mcp_server.fetch: transport "stdio" cannot be bound on target.claude_agents`,
-			},
-		},
-		{
-			name: "a stdio server cannot be bound on the eve target",
-			dir:  "stdio_on_eve",
-			wantErrs: []string{
-				`mcp_server.fetch: transport "stdio" cannot be bound on target.eve; the generated connection is an HTTP client`,
-			},
-		},
-		{
 			name: "auth targets are resolved like any other reference",
 			dir:  "unknown_auth_target",
 			wantErrs: []string{
 				`kastor.hcl: mcp_server.hubspot: auth block 1: unknown reference target.ghost (declared targets: target.langgraph)`,
+			},
+		},
+		{
+			name: "target plugin selector must name a required plugin",
+			dir:  "unknown_plugin_selector",
+			wantErrs: []string{
+				`kastor.hcl: target.python: plugin "langgraph" is not declared in kastor.required_plugins (declared plugins: none declared)`,
 			},
 		},
 	}
@@ -262,6 +247,20 @@ func TestLoadErrors(t *testing.T) {
 				if !strings.Contains(err.Error(), want) {
 					t.Errorf("Load error = %q\nwant substring %q", err, want)
 				}
+			}
+		})
+	}
+}
+
+func TestLoadLeavesPluginCapabilitiesToTheAdapter(t *testing.T) {
+	for _, dir := range []string{"bad_credential_targets", "stdio_on_platform", "stdio_on_eve"} {
+		t.Run(dir, func(t *testing.T) {
+			mod, err := module.Load(filepath.Join("testdata", dir))
+			if err != nil {
+				t.Fatalf("Load: plugin-owned capability checks leaked into core module validation: %v", err)
+			}
+			if len(mod.Plugins) != 1 || mod.Targets[0].Plugin == "" {
+				t.Fatalf("Load: explicit plugin requirement/selector was not retained: %#v, %#v", mod.Plugins, mod.Targets)
 			}
 		})
 	}

--- a/internal/module/testdata/auth_coverage/kastor.hcl
+++ b/internal/module/testdata/auth_coverage/kastor.hcl
@@ -9,8 +9,11 @@ target "langgraph" {
 }
 
 target "claude_agents" {
-  type     = "platform"
-  vault_id = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
+  type = "platform"
+
+  config {
+    vault_id = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
+  }
 }
 
 mcp_server "hubspot" {

--- a/internal/module/testdata/bad_credential_targets/kastor.hcl
+++ b/internal/module/testdata/bad_credential_targets/kastor.hcl
@@ -1,7 +1,7 @@
 kastor {
   required_plugins {
     anthropic = {
-      source  = "github.com/getkastor/kastor-anthropic"
+      source  = "github.com/getkastordev/kastor-anthropic"
       version = "~> 0.1"
     }
   }

--- a/internal/module/testdata/bad_credential_targets/kastor.hcl
+++ b/internal/module/testdata/bad_credential_targets/kastor.hcl
@@ -1,10 +1,20 @@
+kastor {
+  required_plugins {
+    anthropic = {
+      source  = "github.com/getkastor/kastor-anthropic"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
 }
 
-target "claude_agents" {
-  type = "platform"
+target "prod" {
+  type   = "platform"
+  plugin = "anthropic"
 }
 
 mcp_server "hubspot" {

--- a/internal/module/testdata/stdio_on_eve/kastor.hcl
+++ b/internal/module/testdata/stdio_on_eve/kastor.hcl
@@ -1,7 +1,7 @@
 kastor {
   required_plugins {
     eve = {
-      source  = "github.com/getkastor/kastor-eve"
+      source  = "github.com/getkastordev/kastor-eve"
       version = "~> 0.1"
     }
   }

--- a/internal/module/testdata/stdio_on_eve/kastor.hcl
+++ b/internal/module/testdata/stdio_on_eve/kastor.hcl
@@ -1,10 +1,20 @@
+kastor {
+  required_plugins {
+    eve = {
+      source  = "github.com/getkastor/kastor-eve"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
 }
 
-target "eve" {
+target "typescript" {
   type   = "codegen"
+  plugin = "eve"
   output = "./gen/eve"
 }
 

--- a/internal/module/testdata/stdio_on_platform/kastor.hcl
+++ b/internal/module/testdata/stdio_on_platform/kastor.hcl
@@ -1,7 +1,7 @@
 kastor {
   required_plugins {
     anthropic = {
-      source  = "github.com/getkastor/kastor-anthropic"
+      source  = "github.com/getkastordev/kastor-anthropic"
       version = "~> 0.1"
     }
   }

--- a/internal/module/testdata/stdio_on_platform/kastor.hcl
+++ b/internal/module/testdata/stdio_on_platform/kastor.hcl
@@ -1,10 +1,20 @@
+kastor {
+  required_plugins {
+    anthropic = {
+      source  = "github.com/getkastor/kastor-anthropic"
+      version = "~> 0.1"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
 }
 
-target "claude_agents" {
-  type = "platform"
+target "prod" {
+  type   = "platform"
+  plugin = "anthropic"
 }
 
 mcp_server "fetch" {

--- a/internal/module/testdata/unknown_plugin_selector/kastor.hcl
+++ b/internal/module/testdata/unknown_plugin_selector/kastor.hcl
@@ -1,0 +1,5 @@
+target "python" {
+  type   = "codegen"
+  plugin = "langgraph"
+  output = "./gen/python"
+}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -18,9 +19,20 @@ import (
 // projectFileHCL mirrors the raw HCL layout of a project file. It exists only
 // as a decode target; callers get the cleaned-up schema.ProjectFile.
 type projectFileHCL struct {
+	Kastor     *kastorHCL     `hcl:"kastor,block"`
 	Models     []modelHCL     `hcl:"model,block"`
 	Targets    []targetHCL    `hcl:"target,block"`
 	MCPServers []mcpServerHCL `hcl:"mcp_server,block"`
+}
+
+type kastorHCL struct {
+	RequiredPlugins *requiredPluginsHCL `hcl:"required_plugins,block"`
+}
+
+// requiredPluginsHCL is open because each attribute name is a module-local
+// plugin name and its object value contains the installation coordinates.
+type requiredPluginsHCL struct {
+	Body hcl.Body `hcl:",remain"`
 }
 
 type modelHCL struct {
@@ -37,15 +49,13 @@ type paramsHCL struct {
 }
 
 type targetHCL struct {
-	Label   string   `hcl:"name,label"`
-	Type    string   `hcl:"type"`
-	Output  *string  `hcl:"output"`
-	VaultID *string  `hcl:"vault_id"`
-	Auth    *authHCL `hcl:"auth,block"`
-}
-
-type authHCL struct {
-	APIKeyEnv string `hcl:"api_key_env"`
+	Label         string     `hcl:"name,label"`
+	Type          string     `hcl:"type"`
+	Plugin        *string    `hcl:"plugin,optional"`
+	Output        *string    `hcl:"output"`
+	Config        *paramsHCL `hcl:"config,block"`
+	LegacyVaultID *string    `hcl:"vault_id,optional"`
+	LegacyAuth    *paramsHCL `hcl:"auth,block"`
 }
 
 // mcpServerHCL mirrors an mcp_server block (SPEC.md §3.6). Every attribute is
@@ -89,6 +99,13 @@ func ParseProject(filename string, src []byte) (*schema.ProjectFile, error) {
 	}
 
 	project := &schema.ProjectFile{}
+	if raw.Kastor != nil && raw.Kastor.RequiredPlugins != nil {
+		plugins, err := decodeRequiredPlugins(raw.Kastor.RequiredPlugins.Body)
+		if err != nil {
+			return nil, err
+		}
+		project.Plugins = plugins
+	}
 
 	seenModels := map[string]bool{}
 	for _, m := range raw.Models {
@@ -122,15 +139,28 @@ func ParseProject(filename string, src []byte) (*schema.ProjectFile, error) {
 			return nil, fmt.Errorf("%s: declared more than once", target.Addr())
 		}
 		seenTargets[target.Name] = true
+		if t.LegacyVaultID != nil {
+			return nil, fmt.Errorf("%s: \"vault_id\" moved into the plugin-owned config block; use config { vault_id = ... }", target.Addr())
+		}
+		if t.LegacyAuth != nil {
+			return nil, fmt.Errorf("%s: target auth moved into the plugin-owned config block; move its attributes under config { ... }", target.Addr())
+		}
 
 		if t.Output != nil {
 			target.Output = *t.Output
 		}
-		if t.Auth != nil {
-			target.Auth = &schema.Auth{APIKeyEnv: t.Auth.APIKeyEnv}
+		if t.Plugin != nil {
+			target.Plugin = *t.Plugin
+			if target.Plugin == "" {
+				return nil, fmt.Errorf("%s: \"plugin\" cannot be empty; name an entry from kastor.required_plugins", target.Addr())
+			}
 		}
-		if t.VaultID != nil {
-			target.VaultID = *t.VaultID
+		if t.Config != nil {
+			config, err := decodeLiteralAttributes(target.Addr(), "config attribute", t.Config.Body)
+			if err != nil {
+				return nil, err
+			}
+			target.Config = config
 		}
 
 		switch target.Type {
@@ -138,11 +168,7 @@ func ParseProject(filename string, src []byte) (*schema.ProjectFile, error) {
 			if target.Output == "" {
 				return nil, fmt.Errorf("%s: codegen target requires \"output\"", target.Addr())
 			}
-			if target.Auth != nil {
-				return nil, fmt.Errorf("%s: codegen target does not allow \"auth\"", target.Addr())
-			}
 		case "platform":
-			// auth is optional; credentials may come from the environment
 			if t.Output != nil {
 				return nil, fmt.Errorf("%s: platform target does not allow \"output\"", target.Addr())
 			}
@@ -150,17 +176,6 @@ func ParseProject(filename string, src []byte) (*schema.ProjectFile, error) {
 			return nil, fmt.Errorf("%s: invalid type %q (expected \"codegen\" or \"platform\")", target.Addr(), target.Type)
 		}
 
-		// SPEC.md §3.5: vault_id names the Anthropic vault backing this
-		// target's connection:// refs, so it is meaningless anywhere else —
-		// and meaningless fields are errors, not ignored.
-		if t.VaultID != nil {
-			if target.Name != claudeTargetName {
-				return nil, fmt.Errorf("%s: \"vault_id\" is only valid on target %q, which selects the Claude Managed Agents provider", target.Addr(), claudeTargetName)
-			}
-			if target.VaultID == "" {
-				return nil, fmt.Errorf("%s: \"vault_id\" cannot be empty; omit the attribute instead", target.Addr())
-			}
-		}
 		project.Targets = append(project.Targets, target)
 	}
 
@@ -180,9 +195,55 @@ func ParseProject(filename string, src []byte) (*schema.ProjectFile, error) {
 	return project, nil
 }
 
-// claudeTargetName is the target label that selects the Claude Managed Agents
-// provider (SPEC.md §3.5: a platform target's label selects its provider).
-const claudeTargetName = "claude_agents"
+func decodeRequiredPlugins(body hcl.Body) ([]*schema.PluginRequirement, error) {
+	attrs, diags := body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return attrs[names[i]].NameRange.Start.Byte < attrs[names[j]].NameRange.Start.Byte
+	})
+
+	plugins := make([]*schema.PluginRequirement, 0, len(names))
+	for _, name := range names {
+		val, diags := attrs[name].Expr.Value(nil)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		decoded, err := ctyToGo(val)
+		if err != nil {
+			return nil, fmt.Errorf("plugin.%s: %w", name, err)
+		}
+		fields, ok := decoded.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("plugin.%s: requirement must be an object with \"source\" and \"version\"", name)
+		}
+		fieldNames := make([]string, 0, len(fields))
+		for field := range fields {
+			fieldNames = append(fieldNames, field)
+		}
+		sort.Strings(fieldNames)
+		for _, field := range fieldNames {
+			if field != "source" && field != "version" {
+				return nil, fmt.Errorf("plugin.%s: unsupported requirement attribute %q", name, field)
+			}
+		}
+		source, sourceOK := fields["source"].(string)
+		version, versionOK := fields["version"].(string)
+		if !sourceOK || source == "" {
+			return nil, fmt.Errorf("plugin.%s: requirement needs a non-empty string \"source\"", name)
+		}
+		if !versionOK || version == "" {
+			return nil, fmt.Errorf("plugin.%s: requirement needs a non-empty string \"version\"", name)
+		}
+		plugins = append(plugins, &schema.PluginRequirement{Name: name, Source: source, Version: version})
+	}
+	return plugins, nil
+}
 
 // decodeMCPServer decodes one mcp_server block and enforces the per-transport
 // field rules of SPEC.md §3.6. Fields meaningless for a transport are errors,
@@ -257,6 +318,10 @@ func decodeMCPServer(s mcpServerHCL) (*schema.MCPServer, error) {
 
 // decodeParams converts a params block into plain Go values.
 func decodeParams(addr string, body hcl.Body) (map[string]any, error) {
+	return decodeLiteralAttributes(addr, "param", body)
+}
+
+func decodeLiteralAttributes(addr, fieldKind string, body hcl.Body) (map[string]any, error) {
 	attrs, diags := body.JustAttributes()
 	if diags.HasErrors() {
 		return nil, diags
@@ -270,7 +335,7 @@ func decodeParams(addr string, body hcl.Body) (map[string]any, error) {
 		}
 		goVal, err := ctyToGo(val)
 		if err != nil {
-			return nil, fmt.Errorf("%s: param %q: %w", addr, name, err)
+			return nil, fmt.Errorf("%s: %s %q: %w", addr, fieldKind, name, err)
 		}
 		params[name] = goVal
 	}

--- a/internal/parser/project_test.go
+++ b/internal/parser/project_test.go
@@ -23,7 +23,7 @@ func TestParseProjectFile(t *testing.T) {
 			file: "valid_full.hcl",
 			want: &schema.ProjectFile{
 				Plugins: []*schema.PluginRequirement{
-					{Name: "langgraph", Source: "github.com/getkastor/kastor-langgraph", Version: "~> 0.1"},
+					{Name: "langgraph", Source: "github.com/getkastordev/kastor-langgraph", Version: "~> 0.1"},
 					{Name: "assistants", Source: "example.com/acme/assistants", Version: "1.2.0"},
 				},
 				Models: []*schema.Model{
@@ -239,7 +239,7 @@ func TestParseProjectTargetsMayShareAPlugin(t *testing.T) {
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
   }

--- a/internal/parser/project_test.go
+++ b/internal/parser/project_test.go
@@ -22,6 +22,10 @@ func TestParseProjectFile(t *testing.T) {
 			name: "full project file with params, codegen and platform targets",
 			file: "valid_full.hcl",
 			want: &schema.ProjectFile{
+				Plugins: []*schema.PluginRequirement{
+					{Name: "langgraph", Source: "github.com/getkastor/kastor-langgraph", Version: "~> 0.1"},
+					{Name: "assistants", Source: "example.com/acme/assistants", Version: "1.2.0"},
+				},
 				Models: []*schema.Model{
 					{
 						Name:     "fast",
@@ -42,12 +46,14 @@ func TestParseProjectFile(t *testing.T) {
 					{
 						Name:   "langgraph",
 						Type:   "codegen",
+						Plugin: "langgraph",
 						Output: "./gen/langgraph",
 					},
 					{
-						Name: "openai_assistants",
-						Type: "platform",
-						Auth: &schema.Auth{APIKeyEnv: "OPENAI_API_KEY"},
+						Name:   "openai_assistants",
+						Type:   "platform",
+						Plugin: "assistants",
+						Config: map[string]any{"api_key_env": "OPENAI_API_KEY"},
 					},
 				},
 			},
@@ -76,9 +82,9 @@ func TestParseProjectFile(t *testing.T) {
 						Output: "./gen/langgraph",
 					},
 					{
-						Name:    "claude_agents",
-						Type:    "platform",
-						VaultID: "vlt_011CZaBcDeFgHiJkLmNoPqRs",
+						Name:   "claude_agents",
+						Type:   "platform",
+						Config: map[string]any{"vault_id": "vlt_011CZaBcDeFgHiJkLmNoPqRs"},
 					},
 				},
 				MCPServers: []*schema.MCPServer{
@@ -136,9 +142,14 @@ func TestParseProjectFile(t *testing.T) {
 			wantErr: `target.langgraph: codegen target requires "output"`,
 		},
 		{
-			name:    "codegen target rejects auth block",
+			name:    "legacy target auth block has a migration error",
 			file:    "invalid_codegen_auth.hcl",
-			wantErr: `target.langgraph: codegen target does not allow "auth"`,
+			wantErr: `target.langgraph: target auth moved into the plugin-owned config block`,
+		},
+		{
+			name:    "legacy vault attribute has a migration error",
+			file:    "invalid_vault_id_wrong_target.hcl",
+			wantErr: `target.memory: "vault_id" moved into the plugin-owned config block`,
 		},
 		{
 			name:    "platform target rejects output attribute",
@@ -186,9 +197,9 @@ func TestParseProjectFile(t *testing.T) {
 			wantErr: `mcp_server.hubspot: declared more than once`,
 		},
 		{
-			name:    "vault_id is meaningless off the Claude target",
-			file:    "invalid_vault_id_wrong_target.hcl",
-			wantErr: `target.memory: "vault_id" is only valid on target "claude_agents"`,
+			name:    "plugin requirement source cannot be empty",
+			file:    "invalid_plugin_requirement.hcl",
+			wantErr: `plugin.langgraph: requirement needs a non-empty string "source"`,
 		},
 	}
 
@@ -220,5 +231,41 @@ func TestParseProjectFile_MissingFile(t *testing.T) {
 	_, err := parser.ParseProjectFile(filepath.Join("testdata", "does_not_exist.hcl"))
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestParseProjectTargetsMayShareAPlugin(t *testing.T) {
+	project, err := parser.ParseProject("instances.hcl", []byte(`
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+  }
+}
+
+target "preview" {
+  type   = "codegen"
+  plugin = "langgraph"
+  output = "./gen/preview"
+}
+
+target "production" {
+  type   = "codegen"
+  plugin = "langgraph"
+  output = "./gen/production"
+}
+`))
+	if err != nil {
+		t.Fatalf("ParseProject: %v", err)
+	}
+	if len(project.Targets) != 2 {
+		t.Fatalf("targets = %d, want 2", len(project.Targets))
+	}
+	for _, target := range project.Targets {
+		if target.Plugin != "langgraph" {
+			t.Errorf("%s plugin = %q, want langgraph", target.Addr(), target.Plugin)
+		}
 	}
 }

--- a/internal/parser/testdata/invalid_plugin_requirement.hcl
+++ b/internal/parser/testdata/invalid_plugin_requirement.hcl
@@ -1,0 +1,8 @@
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = ""
+      version = "~> 0.1"
+    }
+  }
+}

--- a/internal/parser/testdata/valid_full.hcl
+++ b/internal/parser/testdata/valid_full.hcl
@@ -1,3 +1,16 @@
+kastor {
+  required_plugins {
+    langgraph = {
+      source  = "github.com/getkastor/kastor-langgraph"
+      version = "~> 0.1"
+    }
+    assistants = {
+      source  = "example.com/acme/assistants"
+      version = "1.2.0"
+    }
+  }
+}
+
 model "fast" {
   provider = "openai"
   id       = "gpt-4o-mini"
@@ -15,13 +28,15 @@ model "smart" {
 
 target "langgraph" {
   type   = "codegen"
+  plugin = "langgraph"
   output = "./gen/langgraph"
 }
 
 target "openai_assistants" {
-  type = "platform"
+  type   = "platform"
+  plugin = "assistants"
 
-  auth {
+  config {
     api_key_env = "OPENAI_API_KEY"
   }
 }

--- a/internal/parser/testdata/valid_full.hcl
+++ b/internal/parser/testdata/valid_full.hcl
@@ -1,7 +1,7 @@
 kastor {
   required_plugins {
     langgraph = {
-      source  = "github.com/getkastor/kastor-langgraph"
+      source  = "github.com/getkastordev/kastor-langgraph"
       version = "~> 0.1"
     }
     assistants = {

--- a/internal/parser/testdata/valid_mcp_servers.hcl
+++ b/internal/parser/testdata/valid_mcp_servers.hcl
@@ -4,8 +4,11 @@ target "langgraph" {
 }
 
 target "claude_agents" {
-  type     = "platform"
-  vault_id = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
+  type = "platform"
+
+  config {
+    vault_id = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
+  }
 }
 
 # Remote server, credential held by the platform on one path and by the

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -1,0 +1,25 @@
+package plugin
+
+import (
+	"context"
+
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
+)
+
+// Client is the protocol surface used by the core adapters. Keeping the
+// interface here makes executable-process ownership explicit and lets command
+// tests exercise dispatch without constructing a real protocol.Client.
+type Client interface {
+	Metadata() protocol.Metadata
+	Validate(context.Context, *protocol.ValidateRequest) (*protocol.ValidateResponse, error)
+	Generate(context.Context, *protocol.GenerateRequest) (*protocol.GenerateResponse, error)
+	Read(context.Context, *protocol.ReadRequest) (*protocol.ReadResponse, error)
+	Create(context.Context, *protocol.CreateRequest) (*protocol.CreateResponse, error)
+	Update(context.Context, *protocol.UpdateRequest) error
+	Delete(context.Context, *protocol.DeleteRequest) error
+	Diff(context.Context, *protocol.DiffRequest) (*protocol.DiffResponse, error)
+	Check(context.Context, *protocol.CheckRequest) (*protocol.CheckResponse, error)
+	Close() error
+}
+
+var _ Client = (*protocol.Client)(nil)

--- a/internal/plugin/codegen.go
+++ b/internal/plugin/codegen.go
@@ -8,9 +8,15 @@ import (
 	protocol "github.com/weirdGuy/kastor/protocol/v1"
 )
 
+// CodegenClient is the protocol subset needed for generation.
+type CodegenClient interface {
+	Generate(context.Context, *protocol.GenerateRequest) (*protocol.GenerateResponse, error)
+}
+
 // Codegen adapts a protocol client to the core build.Generator contract.
 type Codegen struct {
-	Client *protocol.Client
+	Client  CodegenClient
+	Context context.Context
 }
 
 var _ build.Generator = (*Codegen)(nil)
@@ -19,7 +25,11 @@ func (g *Codegen) Generate(job *build.Job) ([]build.File, error) {
 	if g == nil || g.Client == nil {
 		return nil, fmt.Errorf("external codegen plugin is not started")
 	}
-	response, err := g.Client.Generate(context.Background(), &protocol.GenerateRequest{
+	ctx := g.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	response, err := g.Client.Generate(ctx, &protocol.GenerateRequest{
 		Module: ModuleIR(job.Module, job.Graph),
 		Target: TargetIR(job.Target),
 	})

--- a/internal/plugin/codegen.go
+++ b/internal/plugin/codegen.go
@@ -1,0 +1,39 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weirdGuy/kastor/internal/build"
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
+)
+
+// Codegen adapts a protocol client to the core build.Generator contract.
+type Codegen struct {
+	Client *protocol.Client
+}
+
+var _ build.Generator = (*Codegen)(nil)
+
+func (g *Codegen) Generate(job *build.Job) ([]build.File, error) {
+	if g == nil || g.Client == nil {
+		return nil, fmt.Errorf("external codegen plugin is not started")
+	}
+	response, err := g.Client.Generate(context.Background(), &protocol.GenerateRequest{
+		Module: ModuleIR(job.Module, job.Graph),
+		Target: TargetIR(job.Target),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, diagnostic := range response.Diagnostics {
+		if diagnostic.Severity == protocol.SeverityError {
+			return nil, fmt.Errorf("%s: %s", diagnostic.Addr, diagnostic.Summary)
+		}
+	}
+	files := make([]build.File, len(response.Files))
+	for i, file := range response.Files {
+		files[i] = build.File{Path: file.Path, Data: file.Data, Preserve: file.Preserve}
+	}
+	return files, nil
+}

--- a/internal/plugin/discovery.go
+++ b/internal/plugin/discovery.go
@@ -1,0 +1,125 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/weirdGuy/kastor/internal/schema"
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
+)
+
+const (
+	pluginDirEnv    = "KASTOR_PLUGIN_DIR"
+	pluginEnvPrefix = "KASTOR_PLUGIN_"
+)
+
+var nonEnv = regexp.MustCompile(`[^A-Za-z0-9]+`)
+
+// Open discovers and starts one declared plugin, then verifies that its
+// handshake identity and version satisfy the module requirement.
+func Open(ctx context.Context, localName string, requirement *schema.PluginRequirement) (*protocol.Client, error) {
+	if requirement == nil {
+		return nil, fmt.Errorf("plugin.%s: requirement is nil", localName)
+	}
+	executable, err := Discover(localName, requirement.Source)
+	if err != nil {
+		return nil, err
+	}
+	client, err := protocol.Start(ctx, executable)
+	if err != nil {
+		return nil, fmt.Errorf("plugin.%s: %w", localName, err)
+	}
+	metadata := client.Metadata()
+	if metadata.Source != requirement.Source {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin.%s: executable %s identifies as %q, expected %q", localName, executable, metadata.Source, requirement.Source)
+	}
+	if !versionMatches(metadata.Version, requirement.Version) {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin.%s: installed version %s does not satisfy %q", localName, metadata.Version, requirement.Version)
+	}
+	return client, nil
+}
+
+// Discover applies the explicit development override first, then a shared
+// plugin directory, then PATH. The executable convention is the final source
+// path segment, e.g. github.com/getkastordev/kastor-eve → kastor-eve.
+func Discover(localName, source string) (string, error) {
+	envName := pluginEnvPrefix + strings.Trim(nonEnv.ReplaceAllString(strings.ToUpper(localName), "_"), "_")
+	if override := os.Getenv(envName); override != "" {
+		return executableFile(override, envName)
+	}
+	binary := path.Base(source)
+	if binary == "." || binary == "/" || binary == "" {
+		return "", fmt.Errorf("plugin.%s: source %q has no executable name", localName, source)
+	}
+	if directory := os.Getenv(pluginDirEnv); directory != "" {
+		candidate := filepath.Join(directory, binary)
+		if resolved, err := executableFile(candidate, pluginDirEnv); err == nil {
+			return resolved, nil
+		}
+	}
+	resolved, err := exec.LookPath(binary)
+	if err != nil {
+		return "", fmt.Errorf("plugin.%s: executable %q not found; install it, add it to PATH, set %s, or set %s", localName, binary, pluginDirEnv, envName)
+	}
+	return resolved, nil
+}
+
+func executableFile(candidate, source string) (string, error) {
+	info, err := os.Stat(candidate)
+	if err != nil {
+		return "", fmt.Errorf("%s points to %q: %w", source, candidate, err)
+	}
+	if info.IsDir() || info.Mode()&0o111 == 0 {
+		return "", fmt.Errorf("%s points to %q, which is not executable", source, candidate)
+	}
+	return filepath.Clean(candidate), nil
+}
+
+func versionMatches(version, constraint string) bool {
+	actual := canonicalVersion(version)
+	if actual == "" {
+		return false
+	}
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		return true
+	}
+	if strings.HasPrefix(constraint, "~>") {
+		base := strings.TrimSpace(strings.TrimPrefix(constraint, "~>"))
+		minimum := canonicalVersion(base)
+		if minimum == "" || semver.Compare(actual, minimum) < 0 {
+			return false
+		}
+		parts := strings.Split(strings.TrimPrefix(minimum, "v"), ".")
+		major, _ := strconv.Atoi(parts[0])
+		minor, _ := strconv.Atoi(parts[1])
+		var maximum string
+		if len(strings.Split(base, ".")) <= 2 {
+			maximum = fmt.Sprintf("v%d.%d.0", major+1, 0)
+		} else {
+			maximum = fmt.Sprintf("v%d.%d.0", major, minor+1)
+		}
+		return semver.Compare(actual, maximum) < 0
+	}
+	wanted := canonicalVersion(strings.TrimPrefix(constraint, "="))
+	return wanted != "" && semver.Compare(actual, wanted) == 0
+}
+
+func canonicalVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return semver.Canonical(version)
+}

--- a/internal/plugin/discovery.go
+++ b/internal/plugin/discovery.go
@@ -26,7 +26,7 @@ var nonEnv = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
 // Open discovers and starts one declared plugin, then verifies that its
 // handshake identity and version satisfy the module requirement.
-func Open(ctx context.Context, localName string, requirement *schema.PluginRequirement) (*protocol.Client, error) {
+func Open(ctx context.Context, localName string, requirement *schema.PluginRequirement) (Client, error) {
 	if requirement == nil {
 		return nil, fmt.Errorf("plugin.%s: requirement is nil", localName)
 	}
@@ -98,7 +98,11 @@ func versionMatches(version, constraint string) bool {
 	if strings.HasPrefix(constraint, "~>") {
 		base := strings.TrimSpace(strings.TrimPrefix(constraint, "~>"))
 		minimum := canonicalVersion(base)
-		if minimum == "" || semver.Compare(actual, minimum) < 0 {
+		rangeVersion := actual
+		if prerelease := semver.Prerelease(rangeVersion); prerelease != "" {
+			rangeVersion = strings.TrimSuffix(rangeVersion, prerelease)
+		}
+		if minimum == "" || semver.Compare(rangeVersion, minimum) < 0 {
 			return false
 		}
 		parts := strings.Split(strings.TrimPrefix(minimum, "v"), ".")
@@ -110,7 +114,7 @@ func versionMatches(version, constraint string) bool {
 		} else {
 			maximum = fmt.Sprintf("v%d.%d.0", major, minor+1)
 		}
-		return semver.Compare(actual, maximum) < 0
+		return semver.Compare(rangeVersion, maximum) < 0
 	}
 	wanted := canonicalVersion(strings.TrimPrefix(constraint, "="))
 	return wanted != "" && semver.Compare(actual, wanted) == 0

--- a/internal/plugin/discovery_test.go
+++ b/internal/plugin/discovery_test.go
@@ -13,6 +13,7 @@ func TestVersionMatches(t *testing.T) {
 		want       bool
 	}{
 		{"0.1.0", "~> 0.1", true},
+		{"0.1.0-dev", "~> 0.1", true},
 		{"0.9.0", "~> 0.1", true},
 		{"1.0.0", "~> 0.1", false},
 		{"0.1.9", "~> 0.1.2", true},

--- a/internal/plugin/discovery_test.go
+++ b/internal/plugin/discovery_test.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVersionMatches(t *testing.T) {
+	tests := []struct {
+		version    string
+		constraint string
+		want       bool
+	}{
+		{"0.1.0", "~> 0.1", true},
+		{"0.9.0", "~> 0.1", true},
+		{"1.0.0", "~> 0.1", false},
+		{"0.1.9", "~> 0.1.2", true},
+		{"0.2.0", "~> 0.1.2", false},
+		{"0.1.0", "0.1.0", true},
+		{"nope", "~> 0.1", false},
+	}
+	for _, test := range tests {
+		if got := versionMatches(test.version, test.constraint); got != test.want {
+			t.Errorf("versionMatches(%q, %q) = %v, want %v", test.version, test.constraint, got, test.want)
+		}
+	}
+}
+
+func TestDiscoverUsesLocalOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugin")
+	if err := os.WriteFile(path, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KASTOR_PLUGIN_LANGGRAPH", path)
+	got, err := Discover("langgraph", "github.com/getkastordev/kastor-langgraph")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != path {
+		t.Fatalf("Discover() = %q, want %q", got, path)
+	}
+}

--- a/internal/plugin/ir.go
+++ b/internal/plugin/ir.go
@@ -1,0 +1,131 @@
+// Package plugin adapts Kastor's internal compiler model to the public
+// protocol-v1 IR and discovers executable target plugins.
+package plugin
+
+import (
+	"github.com/weirdGuy/kastor/internal/graph"
+	"github.com/weirdGuy/kastor/internal/module"
+	"github.com/weirdGuy/kastor/internal/schema"
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
+)
+
+// ModuleIR makes an ownership-separated protocol value. No internal core
+// struct crosses the executable boundary.
+func ModuleIR(mod *module.Module, dependencyGraph *graph.Graph) *protocol.Module {
+	ir := &protocol.Module{Dependencies: map[string][]string{}}
+	for _, model := range mod.Models {
+		ir.Models = append(ir.Models, modelIR(model))
+	}
+	for _, prompt := range mod.Prompts {
+		ir.Prompts = append(ir.Prompts, promptIR(prompt))
+	}
+	for _, tool := range mod.Tools {
+		ir.Tools = append(ir.Tools, toolIR(tool))
+	}
+	for _, agent := range mod.Agents {
+		ir.Agents = append(ir.Agents, agentIR(agent))
+	}
+	for _, target := range mod.Targets {
+		ir.Targets = append(ir.Targets, TargetIR(target))
+	}
+	for _, server := range mod.MCPServers {
+		ir.MCPServers = append(ir.MCPServers, mcpServerIR(server))
+	}
+	if dependencyGraph != nil {
+		ir.TopologicalOrder = append([]string(nil), dependencyGraph.Order()...)
+		for _, addr := range ir.TopologicalOrder {
+			ir.Dependencies[addr] = append([]string(nil), dependencyGraph.Dependencies(addr)...)
+		}
+	}
+	return ir
+}
+
+func TargetIR(target *schema.Target) *protocol.Target {
+	if target == nil {
+		return nil
+	}
+	return &protocol.Target{
+		Name:   target.Name,
+		Type:   target.Type,
+		Plugin: target.Plugin,
+		Output: target.Output,
+		Config: cloneMap(target.Config),
+	}
+}
+
+func modelIR(model *schema.Model) *protocol.Model {
+	return &protocol.Model{Name: model.Name, Provider: model.Provider, ID: model.ID, Params: cloneMap(model.Params)}
+}
+
+func promptIR(prompt *schema.Prompt) *protocol.Prompt {
+	return &protocol.Prompt{
+		Name:     prompt.Name,
+		Requires: append([]string(nil), prompt.Requires...),
+		Body:     prompt.Body,
+		Vars:     append([]string(nil), prompt.Vars...),
+	}
+}
+
+func toolIR(tool *schema.Tool) *protocol.Tool {
+	result := &protocol.Tool{Name: tool.Name, Description: tool.Description}
+	for _, param := range tool.Params {
+		result.Params = append(result.Params, &protocol.ToolParam{
+			Name: param.Name, Type: param.Type, Description: param.Description, Default: param.Default,
+		})
+	}
+	if tool.Returns != nil {
+		result.Returns = &protocol.ToolReturns{Type: tool.Returns.Type}
+	}
+	if tool.Source != nil {
+		result.Source = &protocol.ToolSource{Kind: tool.Source.Kind, URI: tool.Source.URI}
+	}
+	return result
+}
+
+func agentIR(agent *schema.Agent) *protocol.Agent {
+	result := &protocol.Agent{
+		Name:             agent.Name,
+		Description:      agent.Description,
+		Model:            agent.Model,
+		SystemPrompt:     agent.SystemPrompt,
+		Tools:            append([]string(nil), agent.Tools...),
+		RequiresApproval: append([]string(nil), agent.RequiresApproval...),
+		DependsOn:        append([]string(nil), agent.DependsOn...),
+	}
+	for _, input := range agent.Inputs {
+		result.Inputs = append(result.Inputs, &protocol.AgentInput{
+			Name: input.Name, Type: input.Type, Description: input.Description,
+			Optional: input.Optional, Default: input.Default, DefaultRef: input.DefaultRef,
+		})
+	}
+	for _, output := range agent.Outputs {
+		result.Outputs = append(result.Outputs, &protocol.AgentOutput{
+			Name: output.Name, Type: output.Type, Description: output.Description,
+		})
+	}
+	return result
+}
+
+func mcpServerIR(server *schema.MCPServer) *protocol.MCPServer {
+	result := &protocol.MCPServer{
+		Name: server.Name, Transport: server.Transport, URL: server.URL,
+		Command: server.Command, Args: append([]string(nil), server.Args...),
+	}
+	for _, auth := range server.Auth {
+		result.Auth = append(result.Auth, &protocol.MCPAuth{
+			Ref: auth.Ref, Targets: append([]string(nil), auth.Targets...),
+		})
+	}
+	return result
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]any, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}

--- a/internal/plugin/platform.go
+++ b/internal/plugin/platform.go
@@ -9,9 +9,20 @@ import (
 	protocol "github.com/weirdGuy/kastor/protocol/v1"
 )
 
+// PlatformClient is the protocol subset needed for reconciliation.
+type PlatformClient interface {
+	Metadata() protocol.Metadata
+	Read(context.Context, *protocol.ReadRequest) (*protocol.ReadResponse, error)
+	Create(context.Context, *protocol.CreateRequest) (*protocol.CreateResponse, error)
+	Update(context.Context, *protocol.UpdateRequest) error
+	Delete(context.Context, *protocol.DeleteRequest) error
+	Diff(context.Context, *protocol.DiffRequest) (*protocol.DiffResponse, error)
+	Check(context.Context, *protocol.CheckRequest) (*protocol.CheckResponse, error)
+}
+
 // Platform adapts protocol-v1 lifecycle RPCs to the core provider contract.
 type Platform struct {
-	Client *protocol.Client
+	Client PlatformClient
 	Target *schema.Target
 }
 
@@ -82,7 +93,7 @@ func (p *Platform) Check(ctx context.Context, desired *provider.Resource, remote
 	return checks, nil
 }
 
-func (p *Platform) client() *protocol.Client {
+func (p *Platform) client() PlatformClient {
 	if p == nil || p.Client == nil {
 		panic("external platform plugin is not started")
 	}

--- a/internal/plugin/platform.go
+++ b/internal/plugin/platform.go
@@ -1,0 +1,97 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weirdGuy/kastor/internal/provider"
+	"github.com/weirdGuy/kastor/internal/schema"
+	protocol "github.com/weirdGuy/kastor/protocol/v1"
+)
+
+// Platform adapts protocol-v1 lifecycle RPCs to the core provider contract.
+type Platform struct {
+	Client *protocol.Client
+	Target *schema.Target
+}
+
+var (
+	_ provider.Provider = (*Platform)(nil)
+	_ provider.Checker  = (*Platform)(nil)
+)
+
+func (p *Platform) Read(ctx context.Context, id string) (provider.Object, bool, error) {
+	response, err := p.client().Read(ctx, &protocol.ReadRequest{Target: TargetIR(p.Target), ID: id})
+	if err != nil {
+		return nil, false, err
+	}
+	return response.Remote, response.Found, nil
+}
+
+func (p *Platform) Create(ctx context.Context, desired *provider.Resource) (string, error) {
+	response, err := p.client().Create(ctx, &protocol.CreateRequest{
+		Target: TargetIR(p.Target), Desired: resourceIR(desired),
+	})
+	if err != nil {
+		return "", err
+	}
+	return response.ID, nil
+}
+
+func (p *Platform) Update(ctx context.Context, id string, desired *provider.Resource) error {
+	return p.client().Update(ctx, &protocol.UpdateRequest{
+		Target: TargetIR(p.Target), ID: id, Desired: resourceIR(desired),
+	})
+}
+
+func (p *Platform) Delete(ctx context.Context, id string) error {
+	return p.client().Delete(ctx, &protocol.DeleteRequest{Target: TargetIR(p.Target), ID: id})
+}
+
+func (p *Platform) Diff(desired *provider.Resource, remote provider.Object) ([]provider.AttrDiff, error) {
+	response, err := p.client().Diff(context.Background(), &protocol.DiffRequest{
+		Target: TargetIR(p.Target), Desired: resourceIR(desired), Remote: remote,
+	})
+	if err != nil {
+		return nil, err
+	}
+	diffs := make([]provider.AttrDiff, len(response.Diffs))
+	for i, diff := range response.Diffs {
+		diffs[i] = provider.AttrDiff{Path: diff.Path, Old: diff.Old, New: diff.New}
+	}
+	return diffs, nil
+}
+
+func (p *Platform) Check(ctx context.Context, desired *provider.Resource, remote provider.Object) ([]provider.Check, error) {
+	if !p.client().Metadata().Capabilities.Check {
+		return nil, fmt.Errorf("plugin %q does not advertise readiness checks", p.client().Metadata().Source)
+	}
+	response, err := p.client().Check(ctx, &protocol.CheckRequest{
+		Target: TargetIR(p.Target), Desired: resourceIR(desired), Remote: remote,
+	})
+	if err != nil {
+		return nil, err
+	}
+	checks := make([]provider.Check, len(response.Checks))
+	for i, check := range response.Checks {
+		checks[i] = provider.Check{
+			Kind: check.Kind, Status: provider.Status(check.Status), Subject: check.Subject,
+			SubjectName: check.SubjectName, Summary: check.Summary, Detail: check.Detail,
+		}
+	}
+	return checks, nil
+}
+
+func (p *Platform) client() *protocol.Client {
+	if p == nil || p.Client == nil {
+		panic("external platform plugin is not started")
+	}
+	return p.Client
+}
+
+func resourceIR(resource *provider.Resource) *protocol.Resource {
+	if resource == nil {
+		return nil
+	}
+	return &protocol.Resource{Addr: resource.Addr, Config: resource.Config}
+}

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -37,7 +37,7 @@ var (
 type Provider struct {
 	client       anthropic.Client
 	authEnv      string
-	vaultID      string // target.vault_id; read by Check only (SPEC.md §5.3)
+	vaultID      string // target config vault_id; read by Check only (SPEC.md §5.3)
 	sleep        func(context.Context, time.Duration) error
 	createPacer  *requestPacer
 	readPacer    *requestPacer

--- a/internal/provider/claude/claude_test.go
+++ b/internal/provider/claude/claude_test.go
@@ -30,13 +30,13 @@ func TestFactoryResolvesAPIKeyEnvironment(t *testing.T) {
 		}
 	})
 
-	t.Run("target auth block", func(t *testing.T) {
+	t.Run("target config", func(t *testing.T) {
 		const env = "KASTOR_TEST_ANTHROPIC_KEY"
 		t.Setenv(env, testAPIKey)
 		got, err := Factory(&schema.Target{
-			Name: "claude_agents",
-			Type: "platform",
-			Auth: &schema.Auth{APIKeyEnv: env},
+			Name:   "claude_agents",
+			Type:   "platform",
+			Config: map[string]any{"api_key_env": env},
 		})
 		if err != nil || got == nil {
 			t.Fatalf("Factory() = %v, %v; want provider, nil", got, err)
@@ -47,12 +47,34 @@ func TestFactoryResolvesAPIKeyEnvironment(t *testing.T) {
 		const env = "KASTOR_TEST_MISSING_ANTHROPIC_KEY"
 		t.Setenv(env, "")
 		_, err := Factory(&schema.Target{
-			Name: "claude_agents",
-			Type: "platform",
-			Auth: &schema.Auth{APIKeyEnv: env},
+			Name:   "claude_agents",
+			Type:   "platform",
+			Config: map[string]any{"api_key_env": env},
 		})
 		if err == nil || !strings.Contains(err.Error(), env) {
 			t.Fatalf("Factory() error = %v; want missing-key error naming %s", err, env)
+		}
+	})
+
+	t.Run("unknown config", func(t *testing.T) {
+		_, err := Factory(&schema.Target{
+			Name:   "claude_agents",
+			Type:   "platform",
+			Config: map[string]any{"region": "us-east-1"},
+		})
+		if err == nil || !strings.Contains(err.Error(), `unsupported config attribute "region"`) {
+			t.Fatalf("Factory() error = %v; want unsupported-config error", err)
+		}
+	})
+
+	t.Run("config type", func(t *testing.T) {
+		_, err := Factory(&schema.Target{
+			Name:   "claude_agents",
+			Type:   "platform",
+			Config: map[string]any{"api_key_env": int64(1)},
+		})
+		if err == nil || !strings.Contains(err.Error(), "config.api_key_env must be a string") {
+			t.Fatalf("Factory() error = %v; want config type error", err)
 		}
 	})
 }

--- a/internal/provider/claude/factory.go
+++ b/internal/provider/claude/factory.go
@@ -11,18 +11,27 @@ import (
 	"github.com/weirdGuy/kastor/internal/schema"
 )
 
-// Factory resolves the target's API-key environment variable and constructs
-// the registered Claude provider. A target without an auth block uses the
-// documented ambient credential variable.
+// Factory validates the Claude plugin's opaque target config, resolves its
+// API-key environment variable, and constructs the provider. A target without
+// api_key_env uses the documented ambient credential variable.
 func Factory(tgt *schema.Target) (provider.Provider, error) {
 	if tgt == nil {
 		return nil, fmt.Errorf("claude: target is nil")
 	}
+	for key := range tgt.Config {
+		if key != "api_key_env" && key != "vault_id" {
+			return nil, fmt.Errorf("unsupported config attribute %q", key)
+		}
+	}
 	env := defaultAPIKeyEnv
-	if tgt.Auth != nil {
-		env = tgt.Auth.APIKeyEnv
+	if configured, exists := tgt.Config["api_key_env"]; exists {
+		var ok bool
+		env, ok = configured.(string)
+		if !ok {
+			return nil, fmt.Errorf("config.api_key_env must be a string")
+		}
 		if env == "" {
-			return nil, fmt.Errorf("auth.api_key_env is empty; set it to %s", defaultAPIKeyEnv)
+			return nil, fmt.Errorf("config.api_key_env is empty; set it to %s", defaultAPIKeyEnv)
 		}
 	}
 	key, exists := os.LookupEnv(env)
@@ -33,6 +42,12 @@ func Factory(tgt *schema.Target) (provider.Provider, error) {
 	p.authEnv = env
 	// The vault backs kastor doctor's credential verification and nothing
 	// else: plan and apply never contact it (SPEC.md §3.5, §5.3).
-	p.vaultID = tgt.VaultID
+	if configured, exists := tgt.Config["vault_id"]; exists {
+		var ok bool
+		p.vaultID, ok = configured.(string)
+		if !ok {
+			return nil, fmt.Errorf("config.vault_id must be a string")
+		}
+	}
 	return p, nil
 }

--- a/internal/provider/doctor.go
+++ b/internal/provider/doctor.go
@@ -159,9 +159,9 @@ func BuildReport(ctx context.Context, p Provider, job *Job) (*Report, error) {
 func environmentChecks(job *Job) []Check {
 	var checks []Check
 
-	if job.Target.Auth != nil && job.Target.Auth.APIKeyEnv != "" {
+	if apiKeyEnv, ok := job.Target.ConfigString("api_key_env"); ok && apiKeyEnv != "" {
 		checks = append(checks, envCheck(
-			job.Target.Auth.APIKeyEnv,
+			apiKeyEnv,
 			fmt.Sprintf("%s authenticates against this platform", job.Target.Addr()),
 		))
 	}

--- a/internal/provider/memory/memory.go
+++ b/internal/provider/memory/memory.go
@@ -39,12 +39,11 @@ func New() *Provider {
 	return &Provider{Objects: map[string]provider.Object{}}
 }
 
-// Factory adapts New to the CLI's provider registry, validating the target
-// block first: auth is meaningless on an in-memory platform, and meaningless
-// fields are errors, not ignored (SPEC.md §3.5).
+// Factory adapts New to the CLI's provider registry. The in-memory plugin has
+// no configuration schema, so any config entry is rejected rather than ignored.
 func Factory(tgt *schema.Target) (provider.Provider, error) {
-	if tgt.Auth != nil {
-		return nil, fmt.Errorf("auth block found, but the in-memory platform takes no credentials — remove auth from the target block")
+	if len(tgt.Config) > 0 {
+		return nil, fmt.Errorf("config found, but the in-memory platform takes no configuration — remove the config block")
 	}
 	return New(), nil
 }

--- a/internal/provider/memory/memory_test.go
+++ b/internal/provider/memory/memory_test.go
@@ -118,10 +118,10 @@ func TestFactory(t *testing.T) {
 		t.Errorf("Factory on a plain platform target: %v, %v; want a provider, nil", p, err)
 	}
 
-	// Negative: auth is meaningless on an in-memory platform and must be
+	// Negative: config is meaningless on an in-memory platform and must be
 	// rejected, not ignored.
-	_, err = Factory(&schema.Target{Name: "memory", Type: "platform", Auth: &schema.Auth{APIKeyEnv: "NOPE"}})
-	if err == nil || !strings.Contains(err.Error(), "auth") {
-		t.Errorf("Factory with auth: err = %v, want error naming the auth block", err)
+	_, err = Factory(&schema.Target{Name: "memory", Type: "platform", Config: map[string]any{"api_key_env": "NOPE"}})
+	if err == nil || !strings.Contains(err.Error(), "config") {
+		t.Errorf("Factory with config: err = %v, want error naming config", err)
 	}
 }

--- a/internal/provider/testdata/vaulted/kastor.hcl
+++ b/internal/provider/testdata/vaulted/kastor.hcl
@@ -4,11 +4,11 @@ model "fast" {
 }
 
 target "claude_agents" {
-  type     = "platform"
-  vault_id = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
+  type = "platform"
 
-  auth {
+  config {
     api_key_env = "KASTOR_DOCTOR_TEST_KEY"
+    vault_id    = "vlt_011CZaBcDeFgHiJkLmNoPqRs"
   }
 }
 

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -5,10 +5,23 @@ package schema
 // ProjectFile is the decoded form of a project file (kastor.hcl / .kastor).
 // Block order follows source order so downstream output stays deterministic.
 type ProjectFile struct {
+	Plugins    []*PluginRequirement
 	Models     []*Model
 	Targets    []*Target
 	MCPServers []*MCPServer
 }
+
+// PluginRequirement pins the external implementation selected by one or more
+// targets. Name is the module-local identifier used by target.plugin; Source
+// and Version are installation coordinates, not Go package names.
+type PluginRequirement struct {
+	Name    string
+	Source  string
+	Version string
+}
+
+// Addr returns the module-local address used in diagnostics.
+func (p *PluginRequirement) Addr() string { return "plugin." + p.Name }
 
 // Model is a vendor-neutral model definition (SPEC.md §3.1). Agents
 // reference it by address (model.<Name>), never by raw provider strings.
@@ -24,21 +37,23 @@ func (m *Model) Addr() string { return "model." + m.Name }
 
 // Target is a build or deployment destination (SPEC.md §3.5).
 type Target struct {
-	Name   string // block label
-	Type   string // "codegen" or "platform"
-	Output string // codegen only: output directory for generated code
-	Auth   *Auth  // platform only
-	// VaultID names the platform vault holding the credentials this target's
-	// MCP servers reference (claude_agents only). It is a location, not a
-	// secret: only kastor doctor reads it, and only to verify that a
-	// connection:// ref resolves (SPEC.md §3.5, §5.3).
-	VaultID string
+	Name   string         // block label: module-local instance identity
+	Type   string         // "codegen" or "platform"
+	Plugin string         // local name from kastor.required_plugins
+	Output string         // codegen only: output directory for generated code
+	Config map[string]any // opaque plugin-owned configuration
 }
 
 // Addr returns the block address used in references and diagnostics.
 func (t *Target) Addr() string { return "target." + t.Name }
 
-// Auth configures credentials for a platform target.
-type Auth struct {
-	APIKeyEnv string // environment variable holding the API key
+// ConfigString returns one string-valued plugin configuration entry. Keeping
+// this small typed accessor beside the opaque map lets adapters validate their
+// own fields without pushing provider vocabulary back into the core schema.
+func (t *Target) ConfigString(name string) (string, bool) {
+	if t == nil || t.Config == nil {
+		return "", false
+	}
+	value, ok := t.Config[name].(string)
+	return value, ok
 }

--- a/protocol/v1/rpc.go
+++ b/protocol/v1/rpc.go
@@ -222,8 +222,12 @@ type Client struct {
 // Start launches executable with the "serve" argument and performs the
 // mandatory metadata handshake.
 func Start(ctx context.Context, executable string, args ...string) (*Client, error) {
-	lifetime, cancel := context.WithCancel(context.Background())
 	commandArgs := append([]string{"serve"}, args...)
+	return startCommand(ctx, executable, commandArgs)
+}
+
+func startCommand(ctx context.Context, executable string, commandArgs []string) (*Client, error) {
+	lifetime, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(lifetime, executable, commandArgs...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/protocol/v1/rpc.go
+++ b/protocol/v1/rpc.go
@@ -1,0 +1,441 @@
+package protocol
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+const (
+	methodMetadata = "metadata"
+	methodValidate = "validate"
+	methodGenerate = "generate"
+	methodRead     = "read"
+	methodCreate   = "create"
+	methodUpdate   = "update"
+	methodDelete   = "delete"
+	methodDiff     = "diff"
+	methodCheck    = "check"
+)
+
+type wireRequest struct {
+	Protocol int             `json:"protocol"`
+	ID       uint64          `json:"id"`
+	Method   string          `json:"method"`
+	Payload  json.RawMessage `json:"payload,omitempty"`
+}
+
+type wireResponse struct {
+	Protocol int             `json:"protocol"`
+	ID       uint64          `json:"id"`
+	Payload  json.RawMessage `json:"payload,omitempty"`
+	Error    *RemoteError    `json:"error,omitempty"`
+}
+
+// RemoteError is an operation failure returned by the plugin process.
+type RemoteError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *RemoteError) Error() string {
+	if e.Code == "" {
+		return e.Message
+	}
+	return e.Code + ": " + e.Message
+}
+
+// Serve runs a protocol-v1 request loop until the host closes stdin. Plugins
+// must reserve stdout for this function; logs belong on stderr.
+func Serve(in io.Reader, out io.Writer, handler Handler) error {
+	if handler == nil {
+		return fmt.Errorf("protocol v1: nil handler")
+	}
+	decoder := json.NewDecoder(in)
+	writer := bufio.NewWriter(out)
+	encoder := json.NewEncoder(writer)
+	for {
+		var request wireRequest
+		if err := decoder.Decode(&request); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("protocol v1: decode request: %w", err)
+		}
+
+		response := wireResponse{Protocol: Version, ID: request.ID}
+		payload, err := dispatch(context.Background(), handler, request)
+		if err != nil {
+			var remote *RemoteError
+			if errors.As(err, &remote) {
+				response.Error = remote
+			} else {
+				response.Error = &RemoteError{Code: "operation_failed", Message: err.Error()}
+			}
+		} else if payload != nil {
+			response.Payload, err = json.Marshal(payload)
+			if err != nil {
+				response.Error = &RemoteError{Code: "encoding_failed", Message: err.Error()}
+			}
+		}
+		if err := encoder.Encode(response); err != nil {
+			return fmt.Errorf("protocol v1: encode response: %w", err)
+		}
+		if err := writer.Flush(); err != nil {
+			return fmt.Errorf("protocol v1: flush response: %w", err)
+		}
+	}
+}
+
+func dispatch(ctx context.Context, handler Handler, request wireRequest) (any, error) {
+	if request.Protocol != Version {
+		return nil, &RemoteError{
+			Code:    "protocol_mismatch",
+			Message: fmt.Sprintf("host requested protocol %d; plugin supports protocol %d", request.Protocol, Version),
+		}
+	}
+	switch request.Method {
+	case methodMetadata:
+		return handler.Metadata(ctx)
+	case methodValidate:
+		implementation, ok := handler.(Validator)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input ValidateRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return implementation.Validate(ctx, &input)
+	case methodGenerate:
+		implementation, ok := handler.(Generator)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input GenerateRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return implementation.Generate(ctx, &input)
+	case methodRead:
+		implementation, ok := handler.(PlatformProvider)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input ReadRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return implementation.Read(ctx, &input)
+	case methodCreate:
+		implementation, ok := handler.(PlatformProvider)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input CreateRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return implementation.Create(ctx, &input)
+	case methodUpdate:
+		implementation, ok := handler.(PlatformProvider)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input UpdateRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return nil, implementation.Update(ctx, &input)
+	case methodDelete:
+		implementation, ok := handler.(PlatformProvider)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input DeleteRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return nil, implementation.Delete(ctx, &input)
+	case methodDiff:
+		implementation, ok := handler.(PlatformProvider)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input DiffRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return implementation.Diff(ctx, &input)
+	case methodCheck:
+		implementation, ok := handler.(Checker)
+		if !ok {
+			return nil, unsupported(request.Method)
+		}
+		var input CheckRequest
+		if err := decodePayload(request.Payload, &input); err != nil {
+			return nil, err
+		}
+		return implementation.Check(ctx, &input)
+	default:
+		return nil, unsupported(request.Method)
+	}
+}
+
+func decodePayload(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		return &RemoteError{Code: "invalid_request", Message: "request payload is missing"}
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return &RemoteError{Code: "invalid_request", Message: err.Error()}
+	}
+	return nil
+}
+
+func unsupported(method string) error {
+	return &RemoteError{Code: "unsupported_method", Message: fmt.Sprintf("plugin does not implement %q", method)}
+}
+
+// Client owns one plugin subprocess. Calls are serialized because the v1 wire
+// protocol preserves request order; cancellation terminates the process so a
+// stuck plugin cannot leave the host blocked indefinitely.
+type Client struct {
+	mu       sync.Mutex
+	cmd      *exec.Cmd
+	stdin    io.WriteCloser
+	decoder  *json.Decoder
+	encoder  *json.Encoder
+	stderr   *boundedBuffer
+	cancel   context.CancelFunc
+	nextID   uint64
+	closed   bool
+	metadata Metadata
+}
+
+// Start launches executable with the "serve" argument and performs the
+// mandatory metadata handshake.
+func Start(ctx context.Context, executable string, args ...string) (*Client, error) {
+	lifetime, cancel := context.WithCancel(context.Background())
+	commandArgs := append([]string{"serve"}, args...)
+	cmd := exec.CommandContext(lifetime, executable, commandArgs...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("start plugin %s: stdin: %w", executable, err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("start plugin %s: stdout: %w", executable, err)
+	}
+	stderr := &boundedBuffer{limit: 32 * 1024}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start plugin %s: %w", executable, err)
+	}
+
+	client := &Client{
+		cmd:     cmd,
+		stdin:   stdin,
+		decoder: json.NewDecoder(stdout),
+		encoder: json.NewEncoder(stdin),
+		stderr:  stderr,
+		cancel:  cancel,
+	}
+	var metadata Metadata
+	if err := client.call(ctx, methodMetadata, nil, &metadata); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin %s handshake failed: %w", executable, err)
+	}
+	if metadata.Protocol != Version {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin %s protocol mismatch: plugin=%d host=%d", executable, metadata.Protocol, Version)
+	}
+	if metadata.Source == "" || metadata.Version == "" || len(metadata.Kinds) == 0 {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin %s returned incomplete metadata", executable)
+	}
+	client.metadata = metadata
+	return client, nil
+}
+
+func (c *Client) Metadata() Metadata { return c.metadata }
+
+func (c *Client) Validate(ctx context.Context, request *ValidateRequest) (*ValidateResponse, error) {
+	var response ValidateResponse
+	if err := c.call(ctx, methodValidate, request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) Generate(ctx context.Context, request *GenerateRequest) (*GenerateResponse, error) {
+	var response GenerateResponse
+	if err := c.call(ctx, methodGenerate, request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) Read(ctx context.Context, request *ReadRequest) (*ReadResponse, error) {
+	var response ReadResponse
+	if err := c.call(ctx, methodRead, request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) Create(ctx context.Context, request *CreateRequest) (*CreateResponse, error) {
+	var response CreateResponse
+	if err := c.call(ctx, methodCreate, request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) Update(ctx context.Context, request *UpdateRequest) error {
+	return c.call(ctx, methodUpdate, request, nil)
+}
+
+func (c *Client) Delete(ctx context.Context, request *DeleteRequest) error {
+	return c.call(ctx, methodDelete, request, nil)
+}
+
+func (c *Client) Diff(ctx context.Context, request *DiffRequest) (*DiffResponse, error) {
+	var response DiffResponse
+	if err := c.call(ctx, methodDiff, request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) Check(ctx context.Context, request *CheckRequest) (*CheckResponse, error) {
+	var response CheckResponse
+	if err := c.call(ctx, methodCheck, request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) call(ctx context.Context, method string, input, output any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return fmt.Errorf("plugin process is closed")
+	}
+	c.nextID++
+	request := wireRequest{Protocol: Version, ID: c.nextID, Method: method}
+	if input != nil {
+		payload, err := json.Marshal(input)
+		if err != nil {
+			return fmt.Errorf("encode %s request: %w", method, err)
+		}
+		request.Payload = payload
+	}
+	if err := c.encoder.Encode(request); err != nil {
+		return c.processError(fmt.Errorf("send %s request: %w", method, err))
+	}
+
+	type result struct {
+		response wireResponse
+		err      error
+	}
+	completed := make(chan result, 1)
+	go func() {
+		var response wireResponse
+		err := c.decoder.Decode(&response)
+		completed <- result{response: response, err: err}
+	}()
+
+	var received result
+	select {
+	case <-ctx.Done():
+		c.cancel()
+		received = <-completed
+		return fmt.Errorf("plugin %s canceled: %w", method, ctx.Err())
+	case received = <-completed:
+	}
+	if received.err != nil {
+		return c.processError(fmt.Errorf("receive %s response: %w", method, received.err))
+	}
+	response := received.response
+	if response.Protocol != Version {
+		return fmt.Errorf("plugin response protocol mismatch: plugin=%d host=%d", response.Protocol, Version)
+	}
+	if response.ID != request.ID {
+		return fmt.Errorf("plugin response id mismatch: got=%d want=%d", response.ID, request.ID)
+	}
+	if response.Error != nil {
+		return response.Error
+	}
+	if output != nil && len(response.Payload) > 0 {
+		if err := json.Unmarshal(response.Payload, output); err != nil {
+			return fmt.Errorf("decode %s response: %w", method, err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) processError(err error) error {
+	detail := c.stderr.String()
+	if detail == "" {
+		return err
+	}
+	return fmt.Errorf("%w; plugin stderr: %s", err, detail)
+}
+
+func (c *Client) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	_ = c.stdin.Close()
+	c.mu.Unlock()
+	done := make(chan error, 1)
+	go func() { done <- c.cmd.Wait() }()
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(2 * time.Second):
+		c.cancel()
+		err = <-done
+	}
+	c.cancel()
+	if err == nil {
+		return nil
+	}
+	return c.processError(fmt.Errorf("plugin process exited: %w", err))
+}
+
+// boundedBuffer retains the last limit bytes written by a noisy plugin.
+type boundedBuffer struct {
+	mu    sync.Mutex
+	data  []byte
+	limit int
+}
+
+func (b *boundedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.data = append(b.data, data...)
+	if len(b.data) > b.limit {
+		b.data = append([]byte(nil), b.data[len(b.data)-b.limit:]...)
+	}
+	return len(data), nil
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(bytes.TrimSpace(b.data))
+}

--- a/protocol/v1/rpc_test.go
+++ b/protocol/v1/rpc_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 type fakeHandler struct{}
@@ -84,5 +87,65 @@ func TestBoundedBufferKeepsTail(t *testing.T) {
 	}
 	if got := buffer.String(); got != "cdef" {
 		t.Fatalf("String() = %q", got)
+	}
+}
+
+func TestClientRunsExecutablePlugin(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := startCommand(ctx, executable, []string{"-test.run=TestProtocolHelperProcess", "--", "serve"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	if got := client.Metadata().Source; got != "example.test/fake" {
+		t.Fatalf("source = %q", got)
+	}
+	response, err := client.Generate(ctx, &GenerateRequest{Target: &Target{Name: "python"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Files) != 1 || response.Files[0].Path != "python.txt" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestClientReportsPluginCrashStderr(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = startCommand(ctx, executable, []string{"-test.run=TestProtocolHelperProcess", "--", "crash"})
+	if err == nil || !strings.Contains(err.Error(), "deliberate helper crash") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestProtocolHelperProcess(t *testing.T) {
+	marker := ""
+	for i, argument := range os.Args {
+		if argument == "--" && i+1 < len(os.Args) {
+			marker = os.Args[i+1]
+			break
+		}
+	}
+	switch marker {
+	case "serve":
+		if err := Serve(os.Stdin, os.Stdout, fakeHandler{}); err != nil {
+			t.Fatal(err)
+		}
+	case "crash":
+		_, _ = os.Stderr.WriteString("deliberate helper crash\n")
+		os.Exit(23)
 	}
 }

--- a/protocol/v1/rpc_test.go
+++ b/protocol/v1/rpc_test.go
@@ -1,0 +1,88 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+type fakeHandler struct{}
+
+func (fakeHandler) Metadata(context.Context) (Metadata, error) {
+	return Metadata{Protocol: Version, Source: "example.test/fake", Version: "0.1.0", Kinds: []Kind{KindCodegen}}, nil
+}
+
+func (fakeHandler) Generate(_ context.Context, request *GenerateRequest) (*GenerateResponse, error) {
+	return &GenerateResponse{Files: []File{{Path: request.Target.Name + ".txt", Data: []byte("ok")}}}, nil
+}
+
+func TestServeRoundTrip(t *testing.T) {
+	hostToPluginReader, hostToPluginWriter := io.Pipe()
+	pluginToHostReader, pluginToHostWriter := io.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(hostToPluginReader, pluginToHostWriter, fakeHandler{})
+	}()
+
+	encoder := json.NewEncoder(hostToPluginWriter)
+	decoder := json.NewDecoder(pluginToHostReader)
+	payload, err := json.Marshal(&GenerateRequest{Target: &Target{Name: "python"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Encode(wireRequest{Protocol: Version, ID: 7, Method: methodGenerate, Payload: payload}); err != nil {
+		t.Fatal(err)
+	}
+	var response wireResponse
+	if err := decoder.Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.ID != 7 || response.Error != nil {
+		t.Fatalf("response = %#v", response)
+	}
+	var generated GenerateResponse
+	if err := json.Unmarshal(response.Payload, &generated); err != nil {
+		t.Fatal(err)
+	}
+	if len(generated.Files) != 1 || generated.Files[0].Path != "python.txt" || string(generated.Files[0].Data) != "ok" {
+		t.Fatalf("generated = %#v", generated)
+	}
+
+	if err := hostToPluginWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServeRejectsProtocolMismatch(t *testing.T) {
+	request := wireRequest{Protocol: Version + 1, ID: 1, Method: methodMetadata}
+	_, err := dispatch(context.Background(), fakeHandler{}, request)
+	if err == nil {
+		t.Fatal("dispatch succeeded")
+	}
+	remote, ok := err.(*RemoteError)
+	if !ok || remote.Code != "protocol_mismatch" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestServeRejectsUnsupportedMethod(t *testing.T) {
+	_, err := dispatch(context.Background(), fakeHandler{}, wireRequest{Protocol: Version, Method: methodRead, Payload: json.RawMessage(`{"id":"x"}`)})
+	remote, ok := err.(*RemoteError)
+	if !ok || remote.Code != "unsupported_method" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestBoundedBufferKeepsTail(t *testing.T) {
+	buffer := &boundedBuffer{limit: 4}
+	if _, err := buffer.Write([]byte("abcdef")); err != nil {
+		t.Fatal(err)
+	}
+	if got := buffer.String(); got != "cdef" {
+		t.Fatalf("String() = %q", got)
+	}
+}

--- a/protocol/v1/rpc_test.go
+++ b/protocol/v1/rpc_test.go
@@ -13,11 +13,26 @@ import (
 type fakeHandler struct{}
 
 func (fakeHandler) Metadata(context.Context) (Metadata, error) {
-	return Metadata{Protocol: Version, Source: "example.test/fake", Version: "0.1.0", Kinds: []Kind{KindCodegen}}, nil
+	return Metadata{Protocol: Version, Source: "example.test/fake", Version: "0.1.0", Kinds: []Kind{KindCodegen, KindPlatform}}, nil
 }
 
 func (fakeHandler) Generate(_ context.Context, request *GenerateRequest) (*GenerateResponse, error) {
 	return &GenerateResponse{Files: []File{{Path: request.Target.Name + ".txt", Data: []byte("ok")}}}, nil
+}
+
+func (fakeHandler) Read(_ context.Context, request *ReadRequest) (*ReadResponse, error) {
+	return &ReadResponse{Found: true, Remote: Object{"id": request.ID}}, nil
+}
+
+func (fakeHandler) Create(context.Context, *CreateRequest) (*CreateResponse, error) {
+	return &CreateResponse{ID: "fake-created"}, nil
+}
+
+func (fakeHandler) Update(context.Context, *UpdateRequest) error { return nil }
+func (fakeHandler) Delete(context.Context, *DeleteRequest) error { return nil }
+
+func (fakeHandler) Diff(_ context.Context, request *DiffRequest) (*DiffResponse, error) {
+	return &DiffResponse{Diffs: []AttrDiff{{Path: "name", Old: request.Remote["name"], New: request.Desired.Config["name"]}}}, nil
 }
 
 func TestServeRoundTrip(t *testing.T) {
@@ -73,7 +88,7 @@ func TestServeRejectsProtocolMismatch(t *testing.T) {
 }
 
 func TestServeRejectsUnsupportedMethod(t *testing.T) {
-	_, err := dispatch(context.Background(), fakeHandler{}, wireRequest{Protocol: Version, Method: methodRead, Payload: json.RawMessage(`{"id":"x"}`)})
+	_, err := dispatch(context.Background(), fakeHandler{}, wireRequest{Protocol: Version, Method: methodCheck, Payload: json.RawMessage(`{"target":{"name":"prod"}}`)})
 	remote, ok := err.(*RemoteError)
 	if !ok || remote.Code != "unsupported_method" {
 		t.Fatalf("error = %#v", err)
@@ -115,6 +130,17 @@ func TestClientRunsExecutablePlugin(t *testing.T) {
 	}
 	if len(response.Files) != 1 || response.Files[0].Path != "python.txt" {
 		t.Fatalf("response = %#v", response)
+	}
+	diff, err := client.Diff(ctx, &DiffRequest{
+		Target:  &Target{Name: "prod"},
+		Desired: &Resource{Addr: "agent.probe", Config: Object{"name": "desired"}},
+		Remote:  Object{"name": "remote"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diff.Diffs) != 1 || diff.Diffs[0].Path != "name" {
+		t.Fatalf("diff = %#v", diff)
 	}
 }
 

--- a/protocol/v1/types.go
+++ b/protocol/v1/types.go
@@ -33,8 +33,8 @@ type Metadata struct {
 
 // Capabilities describes target validation and optional RPC support.
 type Capabilities struct {
-	LocalProcesses   bool                       `json:"local_processes,omitempty"`
-	CredentialSchemes []string                 `json:"credential_schemes,omitempty"`
+	LocalProcesses    bool                       `json:"local_processes,omitempty"`
+	CredentialSchemes []string                   `json:"credential_schemes,omitempty"`
 	Config            map[string]ConfigAttribute `json:"config,omitempty"`
 	Check             bool                       `json:"check,omitempty"`
 }
@@ -67,13 +67,13 @@ type Diagnostic struct {
 // deterministic and TopologicalOrder is dependencies-first with lexical tie
 // breaking. Dependencies contains sorted direct dependency addresses.
 type Module struct {
-	Agents           []*Agent           `json:"agents,omitempty"`
-	Tools            []*Tool            `json:"tools,omitempty"`
-	Prompts          []*Prompt          `json:"prompts,omitempty"`
-	Models           []*Model           `json:"models,omitempty"`
-	Targets          []*Target          `json:"targets,omitempty"`
-	MCPServers       []*MCPServer       `json:"mcp_servers,omitempty"`
-	TopologicalOrder []string           `json:"topological_order,omitempty"`
+	Agents           []*Agent            `json:"agents,omitempty"`
+	Tools            []*Tool             `json:"tools,omitempty"`
+	Prompts          []*Prompt           `json:"prompts,omitempty"`
+	Models           []*Model            `json:"models,omitempty"`
+	Targets          []*Target           `json:"targets,omitempty"`
+	MCPServers       []*MCPServer        `json:"mcp_servers,omitempty"`
+	TopologicalOrder []string            `json:"topological_order,omitempty"`
 	Dependencies     map[string][]string `json:"dependencies,omitempty"`
 }
 

--- a/protocol/v1/types.go
+++ b/protocol/v1/types.go
@@ -31,6 +31,16 @@ type Metadata struct {
 	Capabilities Capabilities `json:"capabilities"`
 }
 
+// Supports reports whether the plugin advertises an operation family.
+func (m Metadata) Supports(kind Kind) bool {
+	for _, advertised := range m.Kinds {
+		if advertised == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // Capabilities describes target validation and optional RPC support.
 type Capabilities struct {
 	LocalProcesses    bool                       `json:"local_processes,omitempty"`

--- a/protocol/v1/types.go
+++ b/protocol/v1/types.go
@@ -1,0 +1,375 @@
+// Package protocol defines the stable wire contract between Kastor core and
+// executable target plugins. The v1 package contains only serializable data
+// and public interfaces; plugins never need to import Kastor's internal
+// parser, module, build, provider, or state packages.
+package protocol
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Version is the executable protocol version implemented by this package.
+const Version = 1
+
+// Kind identifies the operation family implemented by a plugin.
+type Kind string
+
+const (
+	KindCodegen  Kind = "codegen"
+	KindPlatform Kind = "platform"
+)
+
+// Metadata is returned by the mandatory handshake before any work is sent to
+// a plugin process.
+type Metadata struct {
+	Protocol     int          `json:"protocol"`
+	Source       string       `json:"source"`
+	Version      string       `json:"version"`
+	Kinds        []Kind       `json:"kinds"`
+	Capabilities Capabilities `json:"capabilities"`
+}
+
+// Capabilities describes target validation and optional RPC support.
+type Capabilities struct {
+	LocalProcesses   bool                       `json:"local_processes,omitempty"`
+	CredentialSchemes []string                 `json:"credential_schemes,omitempty"`
+	Config            map[string]ConfigAttribute `json:"config,omitempty"`
+	Check             bool                       `json:"check,omitempty"`
+}
+
+// ConfigAttribute is one plugin-owned target configuration field.
+type ConfigAttribute struct {
+	Type        string `json:"type"`
+	Required    bool   `json:"required,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Severity classifies a structured plugin diagnostic.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Diagnostic is returned for configuration or capability findings that can
+// be attributed to a block address.
+type Diagnostic struct {
+	Severity Severity `json:"severity"`
+	Addr     string   `json:"addr,omitempty"`
+	Summary  string   `json:"summary"`
+	Detail   string   `json:"detail,omitempty"`
+}
+
+// Module is the canonical, fully resolved IR sent to plugins. Slice order is
+// deterministic and TopologicalOrder is dependencies-first with lexical tie
+// breaking. Dependencies contains sorted direct dependency addresses.
+type Module struct {
+	Agents           []*Agent           `json:"agents,omitempty"`
+	Tools            []*Tool            `json:"tools,omitempty"`
+	Prompts          []*Prompt          `json:"prompts,omitempty"`
+	Models           []*Model           `json:"models,omitempty"`
+	Targets          []*Target          `json:"targets,omitempty"`
+	MCPServers       []*MCPServer       `json:"mcp_servers,omitempty"`
+	TopologicalOrder []string           `json:"topological_order,omitempty"`
+	Dependencies     map[string][]string `json:"dependencies,omitempty"`
+}
+
+type Model struct {
+	Name     string         `json:"name"`
+	Provider string         `json:"provider"`
+	ID       string         `json:"id"`
+	Params   map[string]any `json:"params,omitempty"`
+}
+
+func (m *Model) Addr() string { return "model." + m.Name }
+
+type Target struct {
+	Name   string         `json:"name"`
+	Type   string         `json:"type"`
+	Plugin string         `json:"plugin,omitempty"`
+	Output string         `json:"output,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+func (t *Target) Addr() string { return "target." + t.Name }
+
+func (t *Target) ConfigString(name string) (string, bool) {
+	if t == nil || t.Config == nil {
+		return "", false
+	}
+	value, ok := t.Config[name].(string)
+	return value, ok
+}
+
+type Agent struct {
+	Name             string         `json:"name"`
+	Description      string         `json:"description,omitempty"`
+	Model            string         `json:"model"`
+	SystemPrompt     string         `json:"system_prompt,omitempty"`
+	Tools            []string       `json:"tools,omitempty"`
+	RequiresApproval []string       `json:"requires_approval,omitempty"`
+	Inputs           []*AgentInput  `json:"inputs,omitempty"`
+	Outputs          []*AgentOutput `json:"outputs,omitempty"`
+	DependsOn        []string       `json:"depends_on,omitempty"`
+}
+
+func (a *Agent) Addr() string { return "agent." + a.Name }
+
+func (a *Agent) ApprovalRequired(ref string) bool {
+	for _, gated := range a.RequiresApproval {
+		if gated == ref {
+			return true
+		}
+	}
+	return false
+}
+
+type AgentInput struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	Optional    bool   `json:"optional,omitempty"`
+	Default     any    `json:"default,omitempty"`
+	DefaultRef  string `json:"default_ref,omitempty"`
+}
+
+type AgentOutput struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+}
+
+type Tool struct {
+	Name        string       `json:"name"`
+	Description string       `json:"description,omitempty"`
+	Params      []*ToolParam `json:"params,omitempty"`
+	Returns     *ToolReturns `json:"returns"`
+	Source      *ToolSource  `json:"source"`
+}
+
+func (t *Tool) Addr() string { return "tool." + t.Name }
+
+type ToolParam struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	Default     any    `json:"default,omitempty"`
+}
+
+type ToolReturns struct {
+	Type string `json:"type"`
+}
+
+type ToolSource struct {
+	Kind string `json:"kind"`
+	URI  string `json:"uri,omitempty"`
+}
+
+type Prompt struct {
+	Name     string   `json:"name"`
+	Requires []string `json:"requires,omitempty"`
+	Body     string   `json:"body"`
+	Vars     []string `json:"vars,omitempty"`
+}
+
+func (p *Prompt) Addr() string { return "prompt." + p.Name }
+
+type MCPServer struct {
+	Name      string     `json:"name"`
+	Transport string     `json:"transport"`
+	URL       string     `json:"url,omitempty"`
+	Command   string     `json:"command,omitempty"`
+	Args      []string   `json:"args,omitempty"`
+	Auth      []*MCPAuth `json:"auth,omitempty"`
+}
+
+func (s *MCPServer) Addr() string { return "mcp_server." + s.Name }
+
+type MCPAuth struct {
+	Ref     string   `json:"ref"`
+	Targets []string `json:"targets,omitempty"`
+}
+
+func (s *MCPServer) AuthFor(targetAddr string) (*MCPAuth, bool) {
+	var fallback *MCPAuth
+	for _, auth := range s.Auth {
+		if len(auth.Targets) == 0 {
+			fallback = auth
+			continue
+		}
+		for _, target := range auth.Targets {
+			if target == targetAddr {
+				return auth, true
+			}
+		}
+	}
+	if fallback != nil {
+		return fallback, true
+	}
+	return nil, false
+}
+
+const (
+	SchemeEnv        = "env"
+	SchemeConnection = "connection"
+)
+
+func ParseCredentialRef(ref string) (scheme, value string, err error) {
+	scheme, value, found := strings.Cut(ref, "://")
+	if !found || scheme == "" || value == "" {
+		return "", "", fmt.Errorf("credential ref %q is not a complete URI", ref)
+	}
+	if scheme != SchemeEnv && scheme != SchemeConnection {
+		return "", "", fmt.Errorf("credential ref %q uses unknown scheme %q", ref, scheme)
+	}
+	return scheme, value, nil
+}
+
+func ParseMCPURI(uri string) (server, tool string, err error) {
+	const prefix = "mcp://"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", "", fmt.Errorf("MCP source uri is %q, expected mcp://<server>/<tool>", uri)
+	}
+	server, tool, found := strings.Cut(strings.TrimPrefix(uri, prefix), "/")
+	if !found || server == "" || tool == "" || strings.Contains(tool, "/") {
+		return "", "", fmt.Errorf("MCP source uri is %q, expected mcp://<server>/<tool>", uri)
+	}
+	return server, tool, nil
+}
+
+// File is one generated output. Kastor core remains responsible for path
+// validation, canonical ordering, preserve semantics, and disk writes.
+type File struct {
+	Path     string `json:"path"`
+	Data     []byte `json:"data"`
+	Preserve bool   `json:"preserve,omitempty"`
+}
+
+type ValidateRequest struct {
+	Module *Module `json:"module"`
+	Target *Target `json:"target"`
+}
+
+type ValidateResponse struct {
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type GenerateRequest struct {
+	Module *Module `json:"module"`
+	Target *Target `json:"target"`
+}
+
+type GenerateResponse struct {
+	Files       []File       `json:"files,omitempty"`
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+// Object uses encoding/json's value model.
+type Object = map[string]any
+
+type Resource struct {
+	Addr   string `json:"addr"`
+	Config Object `json:"config"`
+}
+
+type AttrDiff struct {
+	Path string `json:"path"`
+	Old  any    `json:"old"`
+	New  any    `json:"new"`
+}
+
+type Status string
+
+const (
+	StatusOK      Status = "ok"
+	StatusFailed  Status = "failed"
+	StatusUnknown Status = "unknown"
+)
+
+type Check struct {
+	Kind        string `json:"kind"`
+	Status      Status `json:"status"`
+	Subject     string `json:"subject,omitempty"`
+	SubjectName string `json:"subject_name,omitempty"`
+	Summary     string `json:"summary"`
+	Detail      string `json:"detail,omitempty"`
+}
+
+type ReadRequest struct {
+	Target *Target `json:"target"`
+	ID     string  `json:"id"`
+}
+
+type ReadResponse struct {
+	Remote Object `json:"remote,omitempty"`
+	Found  bool   `json:"found"`
+}
+
+type CreateRequest struct {
+	Target  *Target   `json:"target"`
+	Desired *Resource `json:"desired"`
+}
+
+type CreateResponse struct {
+	ID string `json:"id"`
+}
+
+type UpdateRequest struct {
+	Target  *Target   `json:"target"`
+	ID      string    `json:"id"`
+	Desired *Resource `json:"desired"`
+}
+
+type DeleteRequest struct {
+	Target *Target `json:"target"`
+	ID     string  `json:"id"`
+}
+
+type DiffRequest struct {
+	Target  *Target   `json:"target"`
+	Desired *Resource `json:"desired"`
+	Remote  Object    `json:"remote,omitempty"`
+}
+
+type DiffResponse struct {
+	Diffs []AttrDiff `json:"diffs,omitempty"`
+}
+
+type CheckRequest struct {
+	Target  *Target   `json:"target"`
+	Desired *Resource `json:"desired"`
+	Remote  Object    `json:"remote,omitempty"`
+}
+
+type CheckResponse struct {
+	Checks []Check `json:"checks,omitempty"`
+}
+
+// Handler is the mandatory plugin surface. Operation-specific interfaces are
+// discovered dynamically, allowing codegen-only and platform-only binaries.
+type Handler interface {
+	Metadata(context.Context) (Metadata, error)
+}
+
+type Validator interface {
+	Validate(context.Context, *ValidateRequest) (*ValidateResponse, error)
+}
+
+type Generator interface {
+	Generate(context.Context, *GenerateRequest) (*GenerateResponse, error)
+}
+
+type PlatformProvider interface {
+	Read(context.Context, *ReadRequest) (*ReadResponse, error)
+	Create(context.Context, *CreateRequest) (*CreateResponse, error)
+	Update(context.Context, *UpdateRequest) error
+	Delete(context.Context, *DeleteRequest) error
+	Diff(context.Context, *DiffRequest) (*DiffResponse, error)
+}
+
+type Checker interface {
+	Check(context.Context, *CheckRequest) (*CheckResponse, error)
+}


### PR DESCRIPTION
## What changed

- add `kastor.required_plugins` source/version declarations and explicit `target.plugin` selectors
- keep target labels as instance/state identity and plugin config as opaque portable data
- add public protocol v1 canonical IR, metadata/capability handshake, structured diagnostics, codegen RPCs, platform lifecycle RPCs, and optional readiness checks
- add persistent executable process management with cancellation, stderr/crash diagnostics, discovery overrides, source/version validation, and target-kind checks
- route every explicit target through its external process for validation and build/plan/apply/destroy/doctor
- retain legacy in-process aliases only for v0.2 compatibility and emit migration guidance; memory remains intentionally built in
- preserve core ownership of graphing, state, plan/apply semantics, generated-file validation, and disk writes
- document manual plugin installation and discovery while automatic installation/lockfiles are tracked separately

## Standalone implementations

- [getkastordev/kastor-langgraph#1](https://github.com/getkastordev/kastor-langgraph/pull/1)
- [getkastordev/kastor-eve#1](https://github.com/getkastordev/kastor-eve/pull/1)
- [getkastordev/kastor-anthropic#1](https://github.com/getkastordev/kastor-anthropic/pull/1)

## Validation

- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- GoReleaser snapshot in core and every plugin repository
- out-of-process codegen and platform fake contract tests
- real cross-repository smoke: core launched all three plugin binaries, generated LangGraph and Eve projects, and planned an Anthropic resource through the external Diff RPC

Linear: KAS-76, KAS-77